### PR TITLE
fix: add install.sh to release package

### DIFF
--- a/mk/cross.mk
+++ b/mk/cross.mk
@@ -1456,6 +1456,7 @@ release-pi: | build/pi/bin/helix-screen build/pi/bin/helix-splash
 	@# Remove any personal config — release ships template only (installer copies it on first run)
 	@rm -f $(RELEASE_DIR)/helixscreen/config/helixconfig.json $(RELEASE_DIR)/helixscreen/config/helixconfig-test.json
 	@mkdir -p $(RELEASE_DIR)/helixscreen/scripts
+	@cp scripts/install.sh $(RELEASE_DIR)/helixscreen/scripts/
 	@cp scripts/uninstall.sh $(RELEASE_DIR)/helixscreen/scripts/
 	@mkdir -p $(RELEASE_DIR)/helixscreen/assets
 	@for asset in $(RELEASE_ASSETS); do \
@@ -1491,6 +1492,7 @@ release-pi32: | build/pi32/bin/helix-screen build/pi32/bin/helix-splash
 	@# Remove any personal config — release ships template only (installer copies it on first run)
 	@rm -f $(RELEASE_DIR)/helixscreen/config/helixconfig.json $(RELEASE_DIR)/helixscreen/config/helixconfig-test.json
 	@mkdir -p $(RELEASE_DIR)/helixscreen/scripts
+	@cp scripts/install.sh $(RELEASE_DIR)/helixscreen/scripts/
 	@cp scripts/uninstall.sh $(RELEASE_DIR)/helixscreen/scripts/
 	@mkdir -p $(RELEASE_DIR)/helixscreen/assets
 	@for asset in $(RELEASE_ASSETS); do \
@@ -1529,6 +1531,7 @@ release-ad5m: | build/ad5m/bin/helix-screen build/ad5m/bin/helix-splash
 	@cp config/presets/ad5m.json $(RELEASE_DIR)/helixscreen/config/helixconfig.json
 	@echo "  $(DIM)Included pre-configured config/helixconfig.json for AD5M Pro$(RESET)"
 	@mkdir -p $(RELEASE_DIR)/helixscreen/scripts
+	@cp scripts/install.sh $(RELEASE_DIR)/helixscreen/scripts/
 	@cp scripts/uninstall.sh $(RELEASE_DIR)/helixscreen/scripts/
 	@mkdir -p $(RELEASE_DIR)/helixscreen/assets
 	@for asset in $(RELEASE_ASSETS); do \
@@ -1570,6 +1573,7 @@ release-k1: | build/k1/bin/helix-screen build/k1/bin/helix-splash
 	@# Remove any personal config — release ships template only (installer copies it on first run)
 	@rm -f $(RELEASE_DIR)/helixscreen/config/helixconfig.json $(RELEASE_DIR)/helixscreen/config/helixconfig-test.json
 	@mkdir -p $(RELEASE_DIR)/helixscreen/scripts
+	@cp scripts/install.sh $(RELEASE_DIR)/helixscreen/scripts/
 	@cp scripts/uninstall.sh $(RELEASE_DIR)/helixscreen/scripts/
 	@mkdir -p $(RELEASE_DIR)/helixscreen/assets
 	@for asset in $(RELEASE_ASSETS); do \
@@ -1604,6 +1608,7 @@ release-k1-dynamic: | build/k1-dynamic/bin/helix-screen build/k1-dynamic/bin/hel
 	@# Remove any personal config — release ships template only (installer copies it on first run)
 	@rm -f $(RELEASE_DIR)/helixscreen/config/helixconfig.json $(RELEASE_DIR)/helixscreen/config/helixconfig-test.json
 	@mkdir -p $(RELEASE_DIR)/helixscreen/scripts
+	@cp scripts/install.sh $(RELEASE_DIR)/helixscreen/scripts/
 	@cp scripts/uninstall.sh $(RELEASE_DIR)/helixscreen/scripts/
 	@mkdir -p $(RELEASE_DIR)/helixscreen/assets
 	@for asset in $(RELEASE_ASSETS); do \
@@ -1638,6 +1643,7 @@ release-k2: | build/k2/bin/helix-screen build/k2/bin/helix-splash
 	@# Remove any personal config — release ships template only (installer copies it on first run)
 	@rm -f $(RELEASE_DIR)/helixscreen/config/helixconfig.json $(RELEASE_DIR)/helixscreen/config/helixconfig-test.json
 	@mkdir -p $(RELEASE_DIR)/helixscreen/scripts
+	@cp scripts/install.sh $(RELEASE_DIR)/helixscreen/scripts/
 	@cp scripts/uninstall.sh $(RELEASE_DIR)/helixscreen/scripts/
 	@mkdir -p $(RELEASE_DIR)/helixscreen/assets
 	@for asset in $(RELEASE_ASSETS); do \
@@ -1671,6 +1677,7 @@ release-snapmaker-u1: | build/snapmaker-u1/bin/helix-screen
 	@cp -r ui_xml config $(RELEASE_DIR)/helixscreen/
 	@rm -f $(RELEASE_DIR)/helixscreen/config/helixconfig.json $(RELEASE_DIR)/helixscreen/config/helixconfig-test.json
 	@mkdir -p $(RELEASE_DIR)/helixscreen/scripts
+	@cp scripts/install.sh $(RELEASE_DIR)/helixscreen/scripts/
 	@cp scripts/uninstall.sh $(RELEASE_DIR)/helixscreen/scripts/ 2>/dev/null || true
 	@mkdir -p $(RELEASE_DIR)/helixscreen/assets
 	@for asset in $(RELEASE_ASSETS); do \


### PR DESCRIPTION
* mitigates update failed when updating from the ui

New version downloads and is verified, but fails with missing installer script error.

Patch adds the install.sh script to the release packages.