### PR TITLE
refactor(ci): use workflow matrix to simplify platform releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,11 +45,26 @@ jobs:
   # ============================================================================
   # Build embedded platform binaries using Docker cross-compilation
   # ============================================================================
-  build-pi:
-    name: Build (Raspberry Pi)
+  build-platforms:
+    name: Build (${{ matrix.display_name }})
     needs: [validate-shell]
     runs-on: ubuntu-22.04
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [pi, pi32, ad5m, k1, k2]
+        include:
+          - platform: pi
+            display_name: "Raspberry Pi"
+          - platform: pi32
+            display_name: "Raspberry Pi 32-bit"
+          - platform: ad5m
+            display_name: "Adventurer 5M"
+          - platform: k1
+            display_name: "Creality K1 Series"
+          - platform: k2
+            display_name: "Creality K2 Series"
 
     steps:
     - name: Checkout repository
@@ -64,27 +79,27 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /tmp/.buildx-cache
-        key: buildx-pi-${{ hashFiles('docker/Dockerfile.pi') }}
+        key: buildx-${{ matrix.platform }}-${{ hashFiles(format('docker/Dockerfile.{0}', matrix.platform)) }}
         restore-keys: |
-          buildx-pi-
+          buildx-${{ matrix.platform }}-
 
-    - name: Build Pi toolchain image
+    - name: Build ${{ matrix.platform }} toolchain image
       run: |
         docker buildx build \
           --cache-from type=local,src=/tmp/.buildx-cache \
           --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
           --load \
-          -t helixscreen/toolchain-pi \
-          -f docker/Dockerfile.pi \
+          -t helixscreen/toolchain-${{ matrix.platform }} \
+          -f docker/Dockerfile.${{ matrix.platform }} \
           docker/
 
-    - name: Cross-compile for Raspberry Pi
+    - name: Cross-compile for ${{ matrix.display_name }}
       run: |
         docker run --rm \
           -v "${{ github.workspace }}":/src \
           -w /src \
-          helixscreen/toolchain-pi \
-          make PLATFORM_TARGET=pi SKIP_OPTIONAL_DEPS=1 -j$(nproc)
+          helixscreen/toolchain-${{ matrix.platform }} \
+          make PLATFORM_TARGET=${{ matrix.platform }} SKIP_OPTIONAL_DEPS=1 -j$(nproc)
 
     # Symbol extraction and stripping are handled by the 'all' target
     # (all → strip → symbols → nm, then strip). No separate steps needed.
@@ -95,314 +110,25 @@ jobs:
     - name: Generate pre-rendered images
       run: make venv-setup && make gen-all-images
 
-    - name: Package Pi release
-      run: make release-pi
+    - name: Package ${{ matrix.platform }} release
+      run: make release-${{ matrix.platform }}
 
-    - name: Upload Pi artifact
+    - name: Upload ${{ matrix.platform }} artifact
       uses: actions/upload-artifact@v4
       with:
-        name: release-pi
+        name: release-${{ matrix.platform }}
         path: |
-          releases/helixscreen-pi-*.tar.gz
-          releases/helixscreen-pi.zip
+          releases/helixscreen-${{ matrix.platform }}-*.tar.gz
+          releases/helixscreen-${{ matrix.platform }}.zip
         retention-days: 7
 
     - name: Upload symbol map artifact
       uses: actions/upload-artifact@v4
       with:
-        name: symbols-pi
-        path: build/pi/bin/helix-screen.sym
+        name: symbols-${{ matrix.platform }}
+        path: build/${{ matrix.platform }}/bin/helix-screen.sym
         retention-days: 30
 
-    # Move cache (prevents cache from growing indefinitely)
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache || true
-
-  build-pi32:
-    name: Build (Raspberry Pi 32-bit)
-    needs: [validate-shell]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 60
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Cache Docker layers
-      uses: actions/cache@v4
-      with:
-        path: /tmp/.buildx-cache
-        key: buildx-pi32-${{ hashFiles('docker/Dockerfile.pi32') }}
-        restore-keys: |
-          buildx-pi32-
-
-    - name: Build Pi 32-bit toolchain image
-      run: |
-        docker buildx build \
-          --cache-from type=local,src=/tmp/.buildx-cache \
-          --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
-          --load \
-          -t helixscreen/toolchain-pi32 \
-          -f docker/Dockerfile.pi32 \
-          docker/
-
-    - name: Cross-compile for Raspberry Pi (32-bit)
-      run: |
-        docker run --rm \
-          -v "${{ github.workspace }}":/src \
-          -w /src \
-          helixscreen/toolchain-pi32 \
-          make PLATFORM_TARGET=pi32 SKIP_OPTIONAL_DEPS=1 -j$(nproc)
-
-    - name: Fix build directory ownership
-      run: sudo chown -R $(id -u):$(id -g) build/
-
-    - name: Generate pre-rendered images
-      run: make venv-setup && make gen-all-images
-
-    - name: Package Pi 32-bit release
-      run: make release-pi32
-
-    - name: Upload Pi 32-bit artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: release-pi32
-        path: |
-          releases/helixscreen-pi32-*.tar.gz
-          releases/helixscreen-pi32.zip
-        retention-days: 7
-
-    - name: Upload symbol map artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: symbols-pi32
-        path: build/pi32/bin/helix-screen.sym
-        retention-days: 30
-
-    # Move cache (prevents cache from growing indefinitely)
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache || true
-
-  build-ad5m:
-    name: Build (Adventurer 5M)
-    needs: [validate-shell]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 60
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Cache Docker layers
-      uses: actions/cache@v4
-      with:
-        path: /tmp/.buildx-cache
-        key: buildx-ad5m-${{ hashFiles('docker/Dockerfile.ad5m') }}
-        restore-keys: |
-          buildx-ad5m-
-
-    - name: Build AD5M toolchain image
-      run: |
-        docker buildx build \
-          --cache-from type=local,src=/tmp/.buildx-cache \
-          --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
-          --load \
-          -t helixscreen/toolchain-ad5m \
-          -f docker/Dockerfile.ad5m \
-          docker/
-
-    - name: Cross-compile for Adventurer 5M
-      run: |
-        docker run --rm \
-          -v "${{ github.workspace }}":/src \
-          -w /src \
-          helixscreen/toolchain-ad5m \
-          make PLATFORM_TARGET=ad5m SKIP_OPTIONAL_DEPS=1 -j$(nproc)
-
-    - name: Fix build directory ownership
-      run: sudo chown -R $(id -u):$(id -g) build/
-
-    - name: Generate pre-rendered images
-      run: make venv-setup && make gen-all-images
-
-    - name: Package AD5M release
-      run: make release-ad5m
-
-    - name: Upload AD5M artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: release-ad5m
-        path: |
-          releases/helixscreen-ad5m-*.tar.gz
-          releases/helixscreen-ad5m.zip
-        retention-days: 7
-
-    - name: Upload symbol map artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: symbols-ad5m
-        path: build/ad5m/bin/helix-screen.sym
-        retention-days: 30
-
-    # Move cache
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache || true
-
-  build-k1:
-    name: Build (Creality K1 Series)
-    needs: [validate-shell]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 60
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Cache Docker layers
-      uses: actions/cache@v4
-      with:
-        path: /tmp/.buildx-cache
-        key: buildx-k1-${{ hashFiles('docker/Dockerfile.k1') }}
-        restore-keys: |
-          buildx-k1-
-
-    - name: Build K1 toolchain image
-      run: |
-        docker buildx build \
-          --cache-from type=local,src=/tmp/.buildx-cache \
-          --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
-          --load \
-          -t helixscreen/toolchain-k1 \
-          -f docker/Dockerfile.k1 \
-          docker/
-
-    - name: Cross-compile for Creality K1
-      run: |
-        docker run --rm \
-          -v "${{ github.workspace }}":/src \
-          -w /src \
-          helixscreen/toolchain-k1 \
-          make PLATFORM_TARGET=k1 SKIP_OPTIONAL_DEPS=1 -j$(nproc)
-
-    - name: Fix build directory ownership
-      run: sudo chown -R $(id -u):$(id -g) build/
-
-    - name: Generate pre-rendered images
-      run: make venv-setup && make gen-all-images
-
-    - name: Package K1 release
-      run: make release-k1
-
-    - name: Upload K1 artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: release-k1
-        path: |
-          releases/helixscreen-k1-*.tar.gz
-          releases/helixscreen-k1.zip
-        retention-days: 7
-
-    - name: Upload symbol map artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: symbols-k1
-        path: build/k1/bin/helix-screen.sym
-        retention-days: 30
-
-    # Move cache
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache || true
-
-  build-k2:
-    name: Build (Creality K2 Series)
-    needs: [validate-shell]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 60
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Cache Docker layers
-      uses: actions/cache@v4
-      with:
-        path: /tmp/.buildx-cache
-        key: buildx-k2-${{ hashFiles('docker/Dockerfile.k2') }}
-        restore-keys: |
-          buildx-k2-
-
-    - name: Build K2 toolchain image
-      run: |
-        docker buildx build \
-          --cache-from type=local,src=/tmp/.buildx-cache \
-          --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
-          --load \
-          -t helixscreen/toolchain-k2 \
-          -f docker/Dockerfile.k2 \
-          docker/
-
-    - name: Cross-compile for Creality K2
-      run: |
-        docker run --rm \
-          -v "${{ github.workspace }}":/src \
-          -w /src \
-          helixscreen/toolchain-k2 \
-          make PLATFORM_TARGET=k2 SKIP_OPTIONAL_DEPS=1 -j$(nproc)
-
-    - name: Fix build directory ownership
-      run: sudo chown -R $(id -u):$(id -g) build/
-
-    - name: Generate pre-rendered images
-      run: make venv-setup && make gen-all-images
-
-    - name: Package K2 release
-      run: make release-k2
-
-    - name: Upload K2 artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: release-k2
-        path: |
-          releases/helixscreen-k2-*.tar.gz
-          releases/helixscreen-k2.zip
-        retention-days: 7
-
-    - name: Upload symbol map artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: symbols-k2
-        path: build/k2/bin/helix-screen.sym
-        retention-days: 30
-
-    # Move cache
     - name: Move cache
       run: |
         rm -rf /tmp/.buildx-cache
@@ -414,7 +140,7 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [build-pi, build-pi32, build-ad5m, build-k1, build-k2]
+    needs: [build-platforms]
     permissions:
       contents: write  # Required to create releases
 

--- a/docs/devel/RELEASE_PROCESS.md
+++ b/docs/devel/RELEASE_PROCESS.md
@@ -55,35 +55,38 @@ git push origin v1.2.0
 
 ### Pipeline Stages
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │                     Tag Push (v1.2.0)                       │
-└─────────────────────┬───────────────────────────────────────┘
-                      │
-    ┌────────────┼────────────┼────────────┐
-    │            │            │            │
-    ▼            ▼            ▼            ▼
-┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐
-│ build-pi │ │build-pi32│ │build-ad5m│ │ build-k1 │
-│ (45 min) │ │ (45 min) │ │ (45 min) │ │ (45 min) │
-│          │ │          │ │          │ │          │
-│ • Docker │ │ • Docker │ │ • Docker │ │ • Docker │
-│ • arm64  │ │ • armhf  │ │ • armv7l │ │ • mips32 │
-│ • Package│ │ • Package│ │ • Package│ │ • Package│
-└────┬─────┘ └────┬─────┘ └────┬─────┘ └────┬─────┘
-     │            │            │            │
-     └────────────┼────────────┼────────────┘
-                  │
-                  ▼
-       ┌──────────────────┐
-       │     release      │
-       │                  │
-       │ • Download all   │
-       │   artifacts      │
-       │ • Extract version│
-       │ • Generate notes │
-       │ • Create release │
-       └──────────────────┘
+└──────────────────────────────┬──────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────┐
+│                         Build Matrix                        │
+└──────────────────────────────┬──────────────────────────────┘
+                               │
+                               ▼
+┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐
+│ build-pi │ │build-pi32│ │build-ad5m│ │ build-k1 │ │ build-k2 │
+│ (45 min) │ │ (45 min) │ │ (45 min) │ │ (45 min) │ │ (45 min) │
+│          │ │          │ │          │ │          │ │          │
+│ • Docker │ │ • Docker │ │ • Docker │ │ • Docker │ │ • Docker │
+│ • arm64  │ │ • armhf  │ │ • armv7l │ │ • mips32 │ │ • mips32 │
+│ • Package│ │ • Package│ │ • Package│ │ • Package│ │ • Package│
+└────┬─────┘ └────┬─────┘ └────┬─────┘ └────┬─────┘ └────┬─────┘
+     │            │            │            │            │
+     └────────────┼────────────┼────────────┼────────────┘
+                               │
+                               ▼
+                     ┌──────────────────┐
+                     │     release      │
+                     │                  │
+                     │ • Download all   │
+                     │   artifacts      │
+                     │ • Extract version│
+                     │ • Generate notes │
+                     │ • Create release │
+                     └──────────────────┘
 ```
 
 ### Build Artifacts
@@ -94,9 +97,7 @@ git push origin v1.2.0
 | Raspberry Pi (32-bit) | `helixscreen-pi32-v{version}.tar.gz` | armhf binary, assets, configs |
 | AD5M | `helixscreen-ad5m-v{version}.tar.gz` | armv7l binary (static), assets, configs |
 | K1/Simple AF | `helixscreen-k1-v{version}.tar.gz` | MIPS32 binary (static, musl), assets, configs |
-
-> **Note:** K1 builds use Docker (`make k1-docker`) with the musl MIPS32 toolchain. CI integration is in progress.
-
+| K2/Simple AF | `helixscreen-k2-v{version}.tar.gz` | ARM binary (static, musl), assets, configs |
 ---
 
 ## Creating a Release


### PR DESCRIPTION
Makes adding platforms a little easier. Just append platforms to the array and create an entry for the display name.