### PR TITLE
feat(backlight): Allwinner: Make display reset configurable

### DIFF
--- a/include/settings_manager.h
+++ b/include/settings_manager.h
@@ -211,14 +211,6 @@ class SettingsManager {
     bool get_sleep_while_printing() const;
 
     /**
-     * @brief Get backlight PWM lifecycle control setting
-     *
-     * When true, use BACKLIGHT_ENABLE/DISABLE ioctls; when false, only set
-     * brightness (avoids driver-side polarity flips on some platforms).
-     */
-    bool get_pwm_lifecycle_control() const;
-
-    /**
      * @brief Set sleep while printing state
      *
      * When enabled (default), the display can dim and sleep during active prints

--- a/src/system/settings_manager.cpp
+++ b/src/system/settings_manager.cpp
@@ -531,11 +531,6 @@ bool SettingsManager::get_sleep_while_printing() const {
     return lv_subject_get_int(const_cast<lv_subject_t*>(&sleep_while_printing_subject_)) != 0;
 }
 
-bool SettingsManager::get_pwm_lifecycle_control() const {
-    Config* config = Config::get_instance();
-    return config->get<bool>("/display/pwm_lifecycle_control", true);
-}
-
 void SettingsManager::set_sleep_while_printing(bool enabled) {
     spdlog::info("[SettingsManager] set_sleep_while_printing({})", enabled);
 


### PR DESCRIPTION
Some Allwinner based displays invert the PWM polarity if the display is disabled. This affects, Elegoo CC1, for example.

With this revision, it can be configured whether a reset shall be performed or not. The default remains true.