### PR TITLE
feat(ui): Support responsive icons

### DIFF
--- a/src/ui/ui_button.cpp
+++ b/src/ui/ui_button.cpp
@@ -36,11 +36,32 @@ struct UiButtonData {
 };
 
 /**
- * @brief Get icon font for button icons (24px MDI)
- * @return Pointer to the MDI 24px icon font
+ * @brief Get icon font for button icons (responsive via icon_font_sm)
+ * @return Pointer to the icon font (adapts to breakpoint)
  */
 static const lv_font_t* get_button_icon_font() {
-    return &mdi_icons_24;
+    const char* font_name = lv_xml_get_const(nullptr, "icon_font_sm");
+    if (!font_name) {
+        spdlog::critical("[ui_button] FATAL: Icon font constant 'icon_font_sm' not found in "
+                         "globals.xml");
+        spdlog::critical("[ui_button] Check that globals.xml defines this constant");
+        std::exit(EXIT_FAILURE);
+    }
+
+    // Get the actual font (FAIL FAST if not compiled)
+    const lv_font_t* font = lv_xml_get_font(nullptr, font_name);
+    if (!font) {
+        spdlog::critical(
+            "[ui_button] FATAL: Icon font '{}' (from constant 'icon_font_sm') is not compiled!",
+            font_name);
+        spdlog::critical("[ui_button] FIX: Enable the icon font in lv_conf.h or regenerate fonts");
+        std::exit(EXIT_FAILURE);
+    }
+
+    spdlog::trace("[ui_button] Using icon font '{}' (from 'icon_font_sm') - line_height={}px",
+                  font_name, lv_font_get_line_height(font));
+
+    return font;
 }
 
 /**

--- a/src/ui/ui_icon.cpp
+++ b/src/ui/ui_icon.cpp
@@ -19,6 +19,7 @@
 
 #include <spdlog/spdlog.h>
 
+#include <cstdlib>
 #include <cstring>
 
 /**
@@ -51,22 +52,58 @@ static IconSize parse_size(const char* size_str) {
 }
 
 /**
- * Get the MDI font for a given size
+ * Get the MDI font for a given size by querying XML constants
+ *
+ * This enables responsive icon fonts.
+ *
+ * IMPORTANT: This function will CRASH if a font is not found. This is
+ * intentional - silent fallbacks cause visual bugs that are hard to debug.
  */
 static const lv_font_t* get_font_for_size(IconSize size) {
+    const char* font_const_name = nullptr;
+
+    // Map icon size to font constant name in globals.xml
     switch (size) {
     case IconSize::XS:
-        return &mdi_icons_16;
+        font_const_name = "icon_font_xs";
+        break;
     case IconSize::SM:
-        return &mdi_icons_24;
+        font_const_name = "icon_font_sm";
+        break;
     case IconSize::MD:
-        return &mdi_icons_32;
+        font_const_name = "icon_font_md";
+        break;
     case IconSize::LG:
-        return &mdi_icons_48;
+        font_const_name = "icon_font_lg";
+        break;
     case IconSize::XL:
     default:
-        return &mdi_icons_64;
+        font_const_name = "icon_font_xl";
+        break;
     }
+
+    // Query font name from XML constant (FAIL FAST if not found)
+    const char* font_name = lv_xml_get_const(nullptr, font_const_name);
+    if (!font_name) {
+        spdlog::critical("[Icon] FATAL: Icon font constant '{}' not found in globals.xml",
+                         font_const_name);
+        spdlog::critical("[Icon] Check that globals.xml defines this constant");
+        std::exit(EXIT_FAILURE);
+    }
+
+    // Get the actual font (FAIL FAST if not compiled)
+    const lv_font_t* font = lv_xml_get_font(nullptr, font_name);
+    if (!font) {
+        spdlog::critical("[Icon] FATAL: Icon font '{}' (from constant '{}') is not compiled!",
+                         font_name, font_const_name);
+        spdlog::critical("[Icon] FIX: Enable the icon font in lv_conf.h or regenerate fonts");
+        std::exit(EXIT_FAILURE);
+    }
+
+    spdlog::trace("[Icon] Applied icon font '{}' (from '{}') - line_height={}px", font_name,
+                  font_const_name, lv_font_get_line_height(font));
+
+    return font;
 }
 
 /**

--- a/ui_xml/globals.xml
+++ b/ui_xml/globals.xml
@@ -260,23 +260,28 @@
     <!-- ===================================================================== -->
     <!-- Icon Typography - Responsive Material Design Icon Fonts               -->
     <!-- ===================================================================== -->
+    <!-- icon_font_xs: Extra-small icons (compact badges, minimal UI elements) -->
+    <string name="icon_font_xs_small" value="mdi_icons_16"/>
+    <string name="icon_font_xs_medium" value="mdi_icons_16"/>
+    <string name="icon_font_xs_large" value="mdi_icons_16"/>
+    <!-- NO BASE icon_font_xs - registered at runtime -->
     <!-- icon_font_sm: Small inline icons (metadata, hints, small indicators) -->
-    <string name="icon_font_sm_small" value="mdi_icons_16"/>
-    <string name="icon_font_sm_medium" value="mdi_icons_16"/>
+    <string name="icon_font_sm_small" value="mdi_icons_24"/>
+    <string name="icon_font_sm_medium" value="mdi_icons_24"/>
     <string name="icon_font_sm_large" value="mdi_icons_24"/>
     <!-- NO BASE icon_font_sm - registered at runtime -->
     <!-- icon_font_md: Standard UI icons (buttons, status, notifications) -->
-    <string name="icon_font_md_small" value="mdi_icons_24"/>
-    <string name="icon_font_md_medium" value="mdi_icons_24"/>
+    <string name="icon_font_md_small" value="mdi_icons_32"/>
+    <string name="icon_font_md_medium" value="mdi_icons_32"/>
     <string name="icon_font_md_large" value="mdi_icons_32"/>
     <!-- NO BASE icon_font_md - registered at runtime -->
     <!-- icon_font_lg: Large icons (cards, status panels, emphasis) -->
-    <string name="icon_font_lg_small" value="mdi_icons_32"/>
+    <string name="icon_font_lg_small" value="mdi_icons_48"/>
     <string name="icon_font_lg_medium" value="mdi_icons_48"/>
     <string name="icon_font_lg_large" value="mdi_icons_48"/>
     <!-- NO BASE icon_font_lg - registered at runtime -->
     <!-- icon_font_xl: Navigation/hero icons (nav bar, large displays) -->
-    <string name="icon_font_xl_small" value="mdi_icons_48"/>
+    <string name="icon_font_xl_small" value="mdi_icons_64"/>
     <string name="icon_font_xl_medium" value="mdi_icons_64"/>
     <string name="icon_font_xl_large" value="mdi_icons_64"/>
     <!-- NO BASE icon_font_xl - registered at runtime -->


### PR DESCRIPTION
This is the third of a series of PRs derived from #85.

This pull request updates the way icon fonts are selected and loaded for UI buttons and icons, making the system more responsive and configurable via the responsive breakpoint tokens.

The breakpoint tokens for the icon font sizes have been updated to match the previous behavior. Apparently they weren't used before.