### PR TITLE
feat(ui): Add animated icons for nozzle and bed temperature to Controls Panel

### DIFF
--- a/include/ui_panel_controls.h
+++ b/include/ui_panel_controls.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "ui_heating_animator.h"
 #include "ui_observer_guard.h"
 #include "ui_panel_base.h"
 #include "ui_print_tune_overlay.h"
@@ -155,6 +156,7 @@ class ControlsPanel : public PanelBase {
     lv_subject_t nozzle_pct_subject_{};
     lv_subject_t nozzle_status_subject_{};
     char nozzle_status_buf_[16] = {};
+    HeatingIconAnimator nozzle_heater_animator_;
 
     // Bed temperature display
     lv_subject_t bed_temp_subject_{};
@@ -162,6 +164,7 @@ class ControlsPanel : public PanelBase {
     lv_subject_t bed_pct_subject_{};
     lv_subject_t bed_status_subject_{};
     char bed_status_buf_[16] = {};
+    HeatingIconAnimator bed_heater_animator_;
 
     // Fan speed display
     lv_subject_t fan_speed_subject_{};

--- a/src/ui/ui_panel_controls.cpp
+++ b/src/ui/ui_panel_controls.cpp
@@ -338,6 +338,16 @@ void ControlsPanel::setup(lv_obj_t* panel, lv_obj_t* parent_screen) {
     // Wire up card click handlers (cards need manual wiring for navigation)
     setup_card_handlers();
 
+    // Attach heating icon animators for nozzle/bed status visualization
+    if (auto* icon = lv_obj_find_by_name(panel_, "nozzle_heater_icon")) {
+        nozzle_heater_animator_.attach(icon);
+        nozzle_heater_animator_.update(cached_extruder_temp_, cached_extruder_target_);
+    }
+    if (auto* icon = lv_obj_find_by_name(panel_, "bed_heater_icon")) {
+        bed_heater_animator_.attach(icon);
+        bed_heater_animator_.update(cached_bed_temp_, cached_bed_target_);
+    }
+
     // Register observers for live data updates
     register_observers();
 
@@ -498,6 +508,8 @@ void ControlsPanel::update_nozzle_temp_display() {
 
     std::snprintf(nozzle_status_buf_, sizeof(nozzle_status_buf_), "%s", result.status.c_str());
     lv_subject_copy_string(&nozzle_status_subject_, nozzle_status_buf_);
+
+    nozzle_heater_animator_.update(cached_extruder_temp_, cached_extruder_target_);
 }
 
 void ControlsPanel::update_bed_temp_display() {
@@ -510,6 +522,8 @@ void ControlsPanel::update_bed_temp_display() {
 
     std::snprintf(bed_status_buf_, sizeof(bed_status_buf_), "%s", result.status.c_str());
     lv_subject_copy_string(&bed_status_subject_, bed_status_buf_);
+
+    bed_heater_animator_.update(cached_bed_temp_, cached_bed_target_);
 }
 
 void ControlsPanel::update_fan_display() {

--- a/ui_xml/controls_panel.xml
+++ b/ui_xml/controls_panel.xml
@@ -130,7 +130,15 @@
                     width="100%" flex_flow="row" style_flex_main_place="space_between" style_flex_cross_place="center"
                     style_margin_top="#space_xs" clickable="true" scrollable="false">
               <event_cb trigger="clicked" callback="on_nozzle_temp_clicked"/>
-              <text_small bind_text="controls_nozzle_label"/>
+              <!-- Left side: animated heater icon + label -->
+              <lv_obj width="content" height="content" flex_flow="row" style_pad_all="0"
+                      scrollable="false" style_flex_cross_place="center" style_pad_gap="#space_xs"
+                      clickable="false" event_bubble="true">
+                <icon name="nozzle_heater_icon" src="heater" size="xs" variant="secondary"
+                      clickable="false" event_bubble="true"/>
+                <text_small bind_text="controls_nozzle_label"/>
+              </lv_obj>
+              <!-- Right side: temp display + edit icon -->
               <lv_obj width="content" height="content" flex_flow="row" style_pad_all="0"
                       scrollable="false" style_flex_cross_place="center" style_pad_gap="#space_xs"
                       clickable="false" event_bubble="true">
@@ -148,7 +156,15 @@
                     width="100%" flex_flow="row" style_flex_main_place="space_between" style_flex_cross_place="center"
                     clickable="true" scrollable="false">
               <event_cb trigger="clicked" callback="on_bed_temp_clicked"/>
-              <text_small text="Bed" translation_tag="Bed"/>
+              <!-- Left side: animated bed icon + label -->
+              <lv_obj width="content" height="content" flex_flow="row" style_pad_all="0"
+                      scrollable="false" style_flex_cross_place="center" style_pad_gap="#space_xs"
+                      clickable="false" event_bubble="true">
+                <icon name="bed_heater_icon" src="radiator" size="xs" variant="secondary"
+                      clickable="false" event_bubble="true"/>
+                <text_small text="Bed" translation_tag="Bed"/>
+              </lv_obj>
+              <!-- Right side: temp display + edit icon -->
               <lv_obj width="content" height="content" flex_flow="row" style_pad_all="0"
                       scrollable="false" style_flex_cross_place="center" style_pad_gap="#space_xs"
                       clickable="false" event_bubble="true">


### PR DESCRIPTION
This is the 5th of a series of PRs derived from #85  .

This pull request adds animated heater icons to the nozzle and bed temperature controls in the UI, improving the visualization of heating status for users. The changes include both UI updates and backend logic to support the new animated icons, ensuring they reflect the current and target temperatures in real time.