### PR TITLE
fix(ui-switch): initialize size preset to silence maybe-uninitialized warning

### DIFF
--- a/src/ui/ui_switch.cpp
+++ b/src/ui/ui_switch.cpp
@@ -162,7 +162,7 @@ static void ui_switch_xml_apply(lv_xml_parser_state_t* state, const char** attrs
     }
 
     // PASS 1: Extract size preset AND explicit dimension overrides
-    SwitchSizePreset preset;
+    SwitchSizePreset preset{};
     bool preset_found = false;
     int32_t explicit_width = -1;
     int32_t explicit_height = -1;


### PR DESCRIPTION
## Preface
This is a very small, defensive cleanup. I’m happy to fold it into a future PR targeting this same area if that’s preferable, since current impact is negligible and I intend to do further work targeting the Creality K1-series/Nebula Pad devices in the future once I've seen how timiv's patches shake out.

## Summary
This PR initializes the local `SwitchSizePreset` in `ui_switch_xml_apply()` with `{}` before optional parsing.

- `SwitchSizePreset preset;` -> `SwitchSizePreset preset{};`

## Why
A clean K1 build was emitting `-Wmaybe-uninitialized` warnings from this code path.  
This warning was pre-existing (not introduced by recent changes).

## Behavior impact
No intended runtime behavior change.  
This is a defensive initialization to make compiler analysis unambiguous.