### PR TITLE
fix(install): make self-update safe under NoNewPrivileges

### DIFF
--- a/scripts/lib/installer/moonraker.sh
+++ b/scripts/lib/installer/moonraker.sh
@@ -171,7 +171,10 @@ write_release_info() {
     cat > "${release_info}.tmp" << EOF
 {"project_name":"helixscreen","project_owner":"prestonbrown","version":"${version}","asset_name":"${asset_name}"}
 EOF
-    $SUDO mv "${release_info}.tmp" "$release_info"
+    # Try without sudo first (self-update: INSTALL_DIR is user-owned under NoNewPrivileges).
+    # Fall back to sudo for fresh installs where the directory may be root-owned.
+    mv "${release_info}.tmp" "$release_info" 2>/dev/null || \
+        $SUDO mv "${release_info}.tmp" "$release_info" 2>/dev/null || true
 }
 
 # Ensure helixscreen is in moonraker.asvc (service allowlist)

--- a/scripts/lib/installer/service.sh
+++ b/scripts/lib/installer/service.sh
@@ -232,10 +232,11 @@ deploy_platform_hooks() {
 
     # Try without sudo first: during self-update INSTALL_DIR is pi-owned so no root
     # is needed.  Fall back to sudo for fresh installs where the directory may be
-    # root-owned or not yet created.
-    mkdir -p "${install_dir}/platform" 2>/dev/null || $SUDO mkdir -p "${install_dir}/platform"
-    cp "$hooks_src" "${install_dir}/platform/hooks.sh" 2>/dev/null || $SUDO cp "$hooks_src" "${install_dir}/platform/hooks.sh"
-    chmod +x "${install_dir}/platform/hooks.sh" 2>/dev/null || $SUDO chmod +x "${install_dir}/platform/hooks.sh"
+    # root-owned or not yet created.  Under NoNewPrivileges sudo is blocked, so
+    # the sudo fallbacks must be silent and non-fatal.
+    mkdir -p "${install_dir}/platform" 2>/dev/null || $SUDO mkdir -p "${install_dir}/platform" 2>/dev/null || true
+    cp "$hooks_src" "${install_dir}/platform/hooks.sh" 2>/dev/null || $SUDO cp "$hooks_src" "${install_dir}/platform/hooks.sh" 2>/dev/null || true
+    chmod +x "${install_dir}/platform/hooks.sh" 2>/dev/null || $SUDO chmod +x "${install_dir}/platform/hooks.sh" 2>/dev/null || true
     log_info "Deployed platform hooks: $platform"
 }
 
@@ -259,7 +260,11 @@ fix_install_ownership() {
 # Stop service for update
 stop_service() {
     if [ "$INIT_SYSTEM" = "systemd" ]; then
-        if systemctl is-active --quiet "$SERVICE_NAME" 2>/dev/null; then
+        # Under NoNewPrivileges (self-update), sudo is blocked.  The service will be
+        # restarted by the watchdog after exit(0) — stopping it here isn't needed.
+        if _has_no_new_privs; then
+            log_info "Skipping service stop (NoNewPrivileges; restart via watchdog)"
+        elif systemctl is-active --quiet "$SERVICE_NAME" 2>/dev/null; then
             log_info "Stopping existing HelixScreen service (systemd)..."
             $SUDO systemctl stop "$SERVICE_NAME" || true
         fi


### PR DESCRIPTION
## Problem

When helix-screen self-updates, `update_checker.cpp` spawns `install.sh` as a child process. The `helixscreen.service` unit has `NoNewPrivileges=true`, which the child process inherits — blocking all `sudo` calls. Under `set -eu`, any unprotected non-zero exit immediately kills the script.

Three code paths were unprotected:

### 1. `deploy_platform_hooks()` — missing `|| true` on sudo fallbacks
```sh
# Before
mkdir -p "${install_dir}/platform" 2>/dev/null || $SUDO mkdir -p "${install_dir}/platform"
cp  ...  2>/dev/null || $SUDO cp  ...
chmod ... 2>/dev/null || $SUDO chmod ...
```
Both non-sudo and sudo paths can fail under NoNewPrivileges (sudo blocked, dir may not exist yet). `set -e` exits 1.

### 2. `write_release_info()` — bare `$SUDO mv` with no fallback
```sh
# Before
$SUDO mv "${release_info}.tmp" "$release_info"
```
On Pi self-update `INSTALL_DIR` is user-owned — no root needed. Under NoNewPrivileges, `$SUDO mv` fails and exits 1.

### 3. `stop_service()` — no `_has_no_new_privs` guard, leaks sudo error to log
```sh
# Before — always tries sudo, produces visible error on every self-update
$SUDO systemctl stop "$SERVICE_NAME" || true
```
Non-fatal due to `|| true`, but produces a confusing sudo error in the journal. The service doesn't need explicit stopping during self-update — the watchdog restarts after `exit(0)`.

## Fix

1. **`deploy_platform_hooks()`** — add `2>/dev/null` and `|| true` to all three sudo fallback lines
2. **`write_release_info()`** — apply the established try-without-sudo pattern (`mv 2>/dev/null || $SUDO mv 2>/dev/null || true`)
3. **`stop_service()` systemd path** — add `_has_no_new_privs()` guard, skip stop and log a clear message; watchdog handles restart via `exit(0)`

`install.sh` re-bundled from modular sources.

## Test plan
- [ ] Self-update on Pi (systemd, `NoNewPrivileges=true`) completes without sudo errors
- [ ] Fresh install on Pi still works (sudo paths still present as fallback)
- [ ] Fresh install on AD5M/K1 unaffected (`SUDO=""` on those platforms)