### PR TITLE
build(k1): static-link libhv OpenSSL and harden docker cross build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -367,6 +367,14 @@ else
     LIBHV_LIBS := $(LIBHV_LIB)
 endif
 
+# libhv generates include/hv headers during libhv-build. Track json.hpp so a
+# stale archive cannot be reused when generated headers are missing.
+ifneq ($(LIBHV_LIB),)
+    LIBHV_JSON_HEADER := $(LIBHV_DIR)/include/hv/json.hpp
+else
+    LIBHV_JSON_HEADER :=
+endif
+
 # spdlog (logging library) - Use system version if available, otherwise use submodule
 # Check for actual header file to avoid $(dir) path issues with directory paths
 SPDLOG_SYSTEM_HEADER_PATHS := /usr/include/spdlog/spdlog.h /usr/local/include/spdlog/spdlog.h /opt/homebrew/include/spdlog/spdlog.h

--- a/Makefile
+++ b/Makefile
@@ -133,8 +133,13 @@ endif
 # Ccache integration - auto-detect and use if available (10x faster rebuilds)
 CCACHE := $(shell command -v ccache 2>/dev/null)
 ifneq ($(CCACHE),)
-    CC := ccache $(CC)
-    CXX := ccache $(CXX)
+    # Avoid double-wrapping when CC/CXX already include ccache (common in CI env).
+    ifneq ($(notdir $(firstword $(CC))),ccache)
+        CC := ccache $(CC)
+    endif
+    ifneq ($(notdir $(firstword $(CXX))),ccache)
+        CXX := ccache $(CXX)
+    endif
 endif
 
 # Dependency generation flags for proper header tracking

--- a/docker/Dockerfile.k1
+++ b/docker/Dockerfile.k1
@@ -61,6 +61,24 @@ RUN wget -q "https://toolchains.bootlin.com/downloads/releases/toolchains/mips32
     mv "mips32el--musl--stable-2024.02-1" mips-toolchain
 
 # ==============================================================================
+# OpenSSL 1.1.1w - Static Cross-Compiled Libraries
+# ==============================================================================
+# Build OpenSSL for MIPS with static linking. The libraries install into the
+# toolchain sysroot so cross-compilation finds them automatically.
+WORKDIR /tmp
+RUN export PATH="/opt/mips-toolchain/bin:$PATH" && \
+    wget -q https://www.openssl.org/source/openssl-1.1.1w.tar.gz && \
+    tar xzf openssl-1.1.1w.tar.gz && \
+    cd openssl-1.1.1w && \
+    ./Configure linux-mips32 no-shared \
+        --cross-compile-prefix=mipsel-buildroot-linux-musl- \
+        --prefix=/opt/mips-toolchain/mipsel-buildroot-linux-musl/sysroot/usr && \
+    make -j$(nproc) && \
+    make install_sw && \
+    cd .. && \
+    rm -rf openssl-1.1.1w openssl-1.1.1w.tar.gz
+
+# ==============================================================================
 # zlib 1.3.2 - Static Cross-Compiled Library
 # ==============================================================================
 # Required for debug bundle gzip compression (debug_bundle_collector.cpp).

--- a/mk/display-lib.mk
+++ b/mk/display-lib.mk
@@ -44,12 +44,12 @@ DISPLAY_CXXFLAGS := $(CXXFLAGS) -I$(INC_DIR) $(LVGL_INC) $(SPDLOG_INC) $(LIBHV_I
 
 # Build object files from src/api/ (with dependency tracking)
 # Depends on LIBHV_LIB to ensure libhv's configure runs first (creates include/hv/*.h)
-$(BUILD_DIR)/display/%.o: src/api/%.cpp $(LIBHV_LIB) | $(BUILD_DIR)/display
+$(BUILD_DIR)/display/%.o: src/api/%.cpp $(LIBHV_LIB) $(LIBHV_JSON_HEADER) | $(BUILD_DIR)/display
 	@echo "[CXX] $<"
 	$(Q)$(CXX) $(DISPLAY_CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 
 # Build object files from src/ui/ (with dependency tracking)
-$(BUILD_DIR)/display/%.o: src/ui/%.cpp $(LIBHV_LIB) | $(BUILD_DIR)/display
+$(BUILD_DIR)/display/%.o: src/ui/%.cpp $(LIBHV_LIB) $(LIBHV_JSON_HEADER) | $(BUILD_DIR)/display
 	@echo "[CXX] $<"
 	$(Q)$(CXX) $(DISPLAY_CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 

--- a/mk/patches.mk
+++ b/mk/patches.mk
@@ -40,6 +40,8 @@ LVGL_PATCHED_FILES := \
 
 # Files modified by libhv patches
 LIBHV_PATCHED_FILES := \
+	Makefile \
+	Makefile.in \
 	http/client/requests.h \
 	base/hsocket.c \
 	base/dns_resolv.c \
@@ -296,6 +298,17 @@ $(PATCHES_STAMP): $(PATCH_FILES) $(LVGL_HEAD) $(LIBHV_HEAD)
 		echo "$(GREEN)✓ LVGL draw_buf OOM guard patch already applied$(RESET)"; \
 	fi
 	$(ECHO) "$(CYAN)Checking libhv patches...$(RESET)"
+	$(Q)if git -C $(LIBHV_DIR) diff --quiet Makefile.in 2>/dev/null; then \
+		echo "$(YELLOW)→ Applying libhv OpenSSL/static build hook patch...$(RESET)"; \
+		if git -C $(LIBHV_DIR) apply --check ../../patches/libhv-openssl-static-link.patch 2>/dev/null; then \
+			git -C $(LIBHV_DIR) apply ../../patches/libhv-openssl-static-link.patch && \
+			echo "$(GREEN)✓ libhv OpenSSL/static build hook patch applied$(RESET)"; \
+		else \
+			echo "$(YELLOW)⚠ Cannot apply patch (already applied or conflicts)$(RESET)"; \
+		fi \
+	else \
+		echo "$(GREEN)✓ libhv OpenSSL/static build hook patch already applied$(RESET)"; \
+	fi
 	$(Q)if git -C $(LIBHV_DIR) diff --quiet http/client/requests.h 2>/dev/null; then \
 		echo "$(YELLOW)→ Applying libhv streaming upload patch...$(RESET)"; \
 		if git -C $(LIBHV_DIR) apply --check ../../patches/libhv-streaming-upload.patch 2>/dev/null; then \

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -154,7 +154,8 @@ endif
 $(TARGET): $(SDL2_LIB) $(LIBHV_LIB) $(LIBHV_JSON_HEADER) $(CONTRIBUTORS_H) $(APP_C_OBJS) $(APP_OBJS) $(APP_MODULE_OBJS) $(OBJCPP_OBJS) $(LVGL_OBJS) $(HELIX_XML_OBJS) $(THORVG_OBJS) $(LVGL_OPENGLES_OBJS) $(LV_MARKDOWN_OBJS) $(FONT_OBJS) $(TRANS_OBJS) $(WPA_DEPS)
 	$(Q)mkdir -p $(BIN_DIR)
 	$(ECHO) "$(MAGENTA)$(BOLD)[LD]$(RESET) $@"
-	$(Q)$(CXX) $(CXXFLAGS) $(filter-out %.a %.h,$^) -o $@ $(LDFLAGS) || { \
+	# Exclude header prerequisites (including .hpp generated deps like hv/json.hpp).
+	$(Q)$(CXX) $(CXXFLAGS) $(filter-out %.a %.h %.hh %.hpp %.hxx,$^) -o $@ $(LDFLAGS) || { \
 		echo "$(RED)$(BOLD)✗ Linking failed!$(RESET)"; \
 		echo "$(YELLOW)Command:$(RESET) $(CXX) $(CXXFLAGS) [objects] -o $@ $(LDFLAGS)"; \
 		exit 1; \

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -140,9 +140,18 @@ endif
 $(LIBHV_LIB):
 	$(Q)$(MAKE) libhv-build
 
+ifneq ($(LIBHV_JSON_HEADER),)
+# Ensure generated libhv headers exist even if the archive is already present.
+$(LIBHV_JSON_HEADER): $(LIBHV_LIB)
+	$(Q)if [ ! -f "$@" ]; then \
+		echo "$(YELLOW)→ libhv generated headers missing; rebuilding libhv...$(RESET)"; \
+		$(MAKE) libhv-build; \
+	fi
+endif
+
 # Link binary (SDL2_LIB is empty if using system SDL2)
-# Note: Filter out library archives from $^ to avoid duplicate linking, then add via LDFLAGS
-$(TARGET): $(SDL2_LIB) $(LIBHV_LIB) $(CONTRIBUTORS_H) $(APP_C_OBJS) $(APP_OBJS) $(APP_MODULE_OBJS) $(OBJCPP_OBJS) $(LVGL_OBJS) $(HELIX_XML_OBJS) $(THORVG_OBJS) $(LVGL_OPENGLES_OBJS) $(LV_MARKDOWN_OBJS) $(FONT_OBJS) $(TRANS_OBJS) $(WPA_DEPS)
+# Keep broad filtering so non-object prerequisites can be added safely later.
+$(TARGET): $(SDL2_LIB) $(LIBHV_LIB) $(LIBHV_JSON_HEADER) $(CONTRIBUTORS_H) $(APP_C_OBJS) $(APP_OBJS) $(APP_MODULE_OBJS) $(OBJCPP_OBJS) $(LVGL_OBJS) $(HELIX_XML_OBJS) $(THORVG_OBJS) $(LVGL_OPENGLES_OBJS) $(LV_MARKDOWN_OBJS) $(FONT_OBJS) $(TRANS_OBJS) $(WPA_DEPS)
 	$(Q)mkdir -p $(BIN_DIR)
 	$(ECHO) "$(MAGENTA)$(BOLD)[LD]$(RESET) $@"
 	$(Q)$(CXX) $(CXXFLAGS) $(filter-out %.a %.h,$^) -o $@ $(LDFLAGS) || { \
@@ -181,7 +190,7 @@ endef
 # Project headers are NOT included - changing app headers should not invalidate PCH
 # The PCH contains only stable, rarely-changing includes (see include/lvgl_pch.h)
 # CRITICAL: lv_conf.h must be listed - it controls LVGL feature flags
-$(PCH): $(PCH_HEADER) $(LIBHV_LIB) lv_conf.h
+$(PCH): $(PCH_HEADER) $(LIBHV_LIB) $(LIBHV_JSON_HEADER) lv_conf.h
 	$(Q)mkdir -p $(dir $@)
 	$(ECHO) "$(MAGENTA)$(BOLD)[PCH]$(RESET) $<"
 ifeq ($(V),1)
@@ -195,7 +204,7 @@ endif
 # Compile app C sources
 # Uses DEPFLAGS to generate .d files for header dependency tracking
 # Emits .ccj fragment for incremental compile_commands.json generation
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c $(LIBHV_LIB)
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c $(LIBHV_LIB) $(LIBHV_JSON_HEADER)
 	$(Q)mkdir -p $(dir $@)
 	$(ECHO) "$(BLUE)[CC]$(RESET) $<"
 ifeq ($(V),1)
@@ -211,7 +220,7 @@ endif
 # Compile app C++ sources (depend on libhv and PCH)
 # Uses DEPFLAGS to generate .d files for header dependency tracking
 # Emits .ccj fragment for incremental compile_commands.json generation
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp $(LIBHV_LIB) $(PCH)
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp $(LIBHV_LIB) $(LIBHV_JSON_HEADER) $(PCH)
 	$(Q)mkdir -p $(dir $@)
 	$(ECHO) "$(BLUE)[CXX]$(RESET) $<"
 ifeq ($(V),1)
@@ -227,7 +236,7 @@ endif
 # Compile app Objective-C++ sources (macOS .mm files)
 # Uses DEPFLAGS to generate .d files for header dependency tracking
 # Emits .ccj fragment for incremental compile_commands.json generation
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.mm $(LIBHV_LIB) $(PCH)
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.mm $(LIBHV_LIB) $(LIBHV_JSON_HEADER) $(PCH)
 	$(Q)mkdir -p $(dir $@)
 	$(ECHO) "$(BLUE)[OBJCXX]$(RESET) $<"
 ifeq ($(V),1)

--- a/mk/splash.mk
+++ b/mk/splash.mk
@@ -47,7 +47,7 @@ ifdef SPLASH_BUILD
 
 # Compile splash source (with dependency tracking for header changes)
 # Depends on LIBHV_LIB to ensure libhv headers are installed before compilation
-$(BUILD_DIR)/splash/%.o: src/%.cpp $(LIBHV_LIB) | $(BUILD_DIR)/splash
+$(BUILD_DIR)/splash/%.o: src/%.cpp $(LIBHV_LIB) $(LIBHV_JSON_HEADER) | $(BUILD_DIR)/splash
 	@echo "[CXX] $< (splash)"
 	$(Q)$(CXX) $(SPLASH_CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 
@@ -58,17 +58,17 @@ $(BUILD_DIR)/splash/%.o: src/%.cpp $(LIBHV_LIB) | $(BUILD_DIR)/splash
 SPLASH_EXTRA_OBJS := $(BUILD_DIR)/splash/config.o $(BUILD_DIR)/splash/backlight_backend.o $(BUILD_DIR)/splash/ui_notification_stub.o
 
 # Compile config for splash (with HELIX_SPLASH_ONLY to guard get_runtime_config dependency)
-$(BUILD_DIR)/splash/config.o: src/system/config.cpp $(LIBHV_LIB) | $(BUILD_DIR)/splash
+$(BUILD_DIR)/splash/config.o: src/system/config.cpp $(LIBHV_LIB) $(LIBHV_JSON_HEADER) | $(BUILD_DIR)/splash
 	@echo "[CXX] $< (splash)"
 	$(Q)$(CXX) $(SPLASH_CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 
 # Compile backlight backend for splash (with HELIX_SPLASH_ONLY to skip runtime_config dependency)
-$(BUILD_DIR)/splash/backlight_backend.o: src/api/backlight_backend.cpp $(LIBHV_LIB) | $(BUILD_DIR)/splash
+$(BUILD_DIR)/splash/backlight_backend.o: src/api/backlight_backend.cpp $(LIBHV_LIB) $(LIBHV_JSON_HEADER) | $(BUILD_DIR)/splash
 	@echo "[CXX] $< (splash)"
 	$(Q)$(CXX) $(SPLASH_CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 
 # Compile notification stub for splash (with dependency tracking)
-$(BUILD_DIR)/splash/ui_notification_stub.o: tools/ui_notification_stub.cpp $(LIBHV_LIB) | $(BUILD_DIR)/splash
+$(BUILD_DIR)/splash/ui_notification_stub.o: tools/ui_notification_stub.cpp $(LIBHV_LIB) $(LIBHV_JSON_HEADER) | $(BUILD_DIR)/splash
 	@echo "[CXX] $< (splash stub)"
 	$(Q)$(CXX) $(SPLASH_CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 

--- a/mk/watchdog.mk
+++ b/mk/watchdog.mk
@@ -57,7 +57,7 @@ ifdef WATCHDOG_BUILD
 
 # Compile watchdog source (with dependency tracking for header changes)
 # Depends on LIBHV_LIB to ensure libhv headers are installed before compilation
-$(BUILD_DIR)/watchdog/%.o: src/%.cpp $(LIBHV_LIB) | $(BUILD_DIR)/watchdog
+$(BUILD_DIR)/watchdog/%.o: src/%.cpp $(LIBHV_LIB) $(LIBHV_JSON_HEADER) | $(BUILD_DIR)/watchdog
 	@echo "[CXX] $< (watchdog)"
 	$(Q)$(CXX) $(WATCHDOG_CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 
@@ -70,22 +70,22 @@ WATCHDOG_EXTRA_OBJS := $(BUILD_DIR)/watchdog/config.o \
                        $(BUILD_DIR)/watchdog/ui_notification_stub.o
 
 # Compile config for watchdog (with HELIX_WATCHDOG to guard get_runtime_config dependency)
-$(BUILD_DIR)/watchdog/config.o: src/system/config.cpp $(LIBHV_LIB) | $(BUILD_DIR)/watchdog
+$(BUILD_DIR)/watchdog/config.o: src/system/config.cpp $(LIBHV_LIB) $(LIBHV_JSON_HEADER) | $(BUILD_DIR)/watchdog
 	@echo "[CXX] $< (watchdog)"
 	$(Q)$(CXX) $(WATCHDOG_CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 
 # Compile backlight backend for watchdog (with HELIX_WATCHDOG to skip runtime_config dependency)
-$(BUILD_DIR)/watchdog/backlight_backend.o: src/api/backlight_backend.cpp $(LIBHV_LIB) | $(BUILD_DIR)/watchdog
+$(BUILD_DIR)/watchdog/backlight_backend.o: src/api/backlight_backend.cpp $(LIBHV_LIB) $(LIBHV_JSON_HEADER) | $(BUILD_DIR)/watchdog
 	@echo "[CXX] $< (watchdog)"
 	$(Q)$(CXX) $(WATCHDOG_CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 
 # Compile logging_init for watchdog
-$(BUILD_DIR)/watchdog/logging_init.o: src/system/logging_init.cpp $(LIBHV_LIB) | $(BUILD_DIR)/watchdog
+$(BUILD_DIR)/watchdog/logging_init.o: src/system/logging_init.cpp $(LIBHV_LIB) $(LIBHV_JSON_HEADER) | $(BUILD_DIR)/watchdog
 	@echo "[CXX] $< (watchdog)"
 	$(Q)$(CXX) $(WATCHDOG_CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 
 # Compile notification stub for watchdog (with dependency tracking)
-$(BUILD_DIR)/watchdog/ui_notification_stub.o: tools/ui_notification_stub.cpp $(LIBHV_LIB) | $(BUILD_DIR)/watchdog
+$(BUILD_DIR)/watchdog/ui_notification_stub.o: tools/ui_notification_stub.cpp $(LIBHV_LIB) $(LIBHV_JSON_HEADER) | $(BUILD_DIR)/watchdog
 	@echo "[CXX] $< (watchdog stub)"
 	$(Q)$(CXX) $(WATCHDOG_CXXFLAGS) $(DEPFLAGS) -c $< -o $@
 

--- a/patches/libhv-openssl-static-link.patch
+++ b/patches/libhv-openssl-static-link.patch
@@ -1,0 +1,38 @@
+diff --git a/Makefile b/Makefile
+index c06b8a7..c50b3ec 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2,6 +2,9 @@ include config.mk
+ include Makefile.vars
+ 
+ MAKEF=$(MAKE) -f Makefile.in
++# Allow callers to force static-only outputs (used by cross builds that only
++# consume libhv.a and may ship static-only OpenSSL toolchains).
++LIBHV_TARGET_TYPE ?= SHARED|STATIC
+ ALL_SRCDIRS=. base ssl event event/kcp util cpputil evpp protocol http http/client http/server mqtt
+ CORE_SRCDIRS=. base ssl event
+ ifeq ($(WITH_KCP), yes)
+@@ -84,7 +87,7 @@ prepare:
+ 
+ libhv:
+ 	$(MKDIR) lib
+-	$(MAKEF) TARGET=$@ TARGET_TYPE="SHARED|STATIC" SRCDIRS="$(LIBHV_SRCDIRS)"
++	$(MAKEF) TARGET=$@ TARGET_TYPE="$(LIBHV_TARGET_TYPE)" SRCDIRS="$(LIBHV_SRCDIRS)"
+ 	$(MKDIR) include/hv
+ 	$(CP) $(LIBHV_HEADERS) include/hv
+ 	@echo "make libhv done."
+diff --git a/Makefile.in b/Makefile.in
+index cceb29d..2ec47e0 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -180,7 +180,9 @@ endif
+ 
+ ifeq ($(WITH_OPENSSL), yes)
+ 	CPPFLAGS += -DWITH_OPENSSL
+-	LDFLAGS += -lssl -lcrypto
++	# Allow downstream build systems to force static archives or alternate paths.
++	OPENSSL_LIBS ?= -lssl -lcrypto
++	LDFLAGS += $(OPENSSL_LIBS)
+ else
+ ifeq ($(WITH_GNUTLS), yes)
+ 	CPPFLAGS += -DWITH_GNUTLS

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -217,13 +217,19 @@ check_libraries() {
             # but OpenSSL installs to <prefix>/<triple>/include (one level up from libc)
             SSL_FOUND=0
             SYSROOT=$("$CC" -print-sysroot 2>/dev/null || true)
-            if [ -n "$SYSROOT" ] && [ -f "$SYSROOT/include/openssl/ssl.h" ]; then
+            if [ -n "$SYSROOT" ] && [ -f "$SYSROOT/usr/include/openssl/ssl.h" ]; then
+                ok "OpenSSL found (cross-compiler sysroot/usr)"
+                SSL_FOUND=1
+            elif [ -n "$SYSROOT" ] && [ -f "$SYSROOT/include/openssl/ssl.h" ]; then
                 ok "OpenSSL found (cross-compiler sysroot)"
                 SSL_FOUND=1
             elif [ -n "$SYSROOT" ]; then
                 TOOLCHAIN_PREFIX=$(dirname "$SYSROOT")
                 if [ -f "$TOOLCHAIN_PREFIX/include/openssl/ssl.h" ]; then
                     ok "OpenSSL found (toolchain: $TOOLCHAIN_PREFIX)"
+                    SSL_FOUND=1
+                elif [ -f "$TOOLCHAIN_PREFIX/sysroot/usr/include/openssl/ssl.h" ]; then
+                    ok "OpenSSL found (toolchain sysroot/usr: $TOOLCHAIN_PREFIX)"
                     SSL_FOUND=1
                 fi
             fi


### PR DESCRIPTION
## Summary

* Add a dedicated `libhv` patch to statically link OpenSSL from the K1 toolchain sysroot
* Integrate the K1 patch into the existing patch pipeline so it applies cleanly alongside the upstream patch series
* Harden the MIPS Docker cross-build `make` invocation and dependency flags to prevent recursive make / jobserver instability
* Ensure deterministic regeneration of `libhv` headers and libraries for cross-target builds

## Why

K1/KE-class Buildroot systems may lack curl/HTTPS support in their base image paths. To ensure reliable builds and runtime behavior, `libhv` must statically link OpenSSL and follow a reproducible cross-build process aligned with the existing patch workflow.

## Validation

* `make k1-docker`
* `make release-k1`
* Confirmed K1 release artifacts were generated successfully
