### PR TITLE
fix(api): avoid structured-binding capture in MoonrakerRestAPI dtor

### DIFF
--- a/src/api/moonraker_rest_api.cpp
+++ b/src/api/moonraker_rest_api.cpp
@@ -85,7 +85,8 @@ MoonrakerRestAPI::~MoonrakerRestAPI() {
     constexpr auto kJoinTimeout = std::chrono::seconds(2);
     constexpr auto kPollInterval = std::chrono::milliseconds(10);
 
-    for (auto& [t, _] : threads_to_join) {
+    for (auto& thread_entry : threads_to_join) {
+        auto& t = thread_entry.first;
         if (!t.joinable()) {
             continue;
         }


### PR DESCRIPTION
## Summary
- replace structured binding loop variable usage in `MoonrakerRestAPI::~MoonrakerRestAPI` with a named pair entry
- capture/join the thread via the named reference (`thread_entry.first`) so clang C++17 accepts the lambda capture

## Why
CI clang build fails with:
- `error: 't' in capture list does not name a variable`

This makes the destructor implementation C++17/clang-compatible without changing behavior.

## Validation
- compiled `src/api/moonraker_rest_api.cpp` with the same CI-style clang command and flags