### PR TITLE
build(k1): disable TinyGL software 3D on mips target

### DIFF
--- a/mk/cross.mk
+++ b/mk/cross.mk
@@ -350,6 +350,8 @@ else ifneq ($(filter mips k1,$(PLATFORM_TARGET)),)
     ENABLE_SDL := no
     ENABLE_GLES_3D := no
     ENABLE_SCREENSAVER := no
+    # K1/XBurst2 performs poorly with software 3D; use 2D preview path.
+    ENABLE_TINYGL_3D := no
     ENABLE_EVDEV := yes
     BUILD_SUBDIR := mips
     # Strip binary for size on memory-constrained device


### PR DESCRIPTION
## Summary
- disable TinyGL software 3D for the `mips|k1` target by setting `ENABLE_TINYGL_3D := no`
- keep this change separate from the K1 OpenSSL/libhv installation/build fixes

## Why
`ad5x` already disables TinyGL due to software-rendered 3D performance constraints. K1 uses Ingenic XBurst2-class hardware with similar limits, so this keeps behavior aligned and avoids unnecessary TinyGL build/runtime overhead on K1.

## Scope
- one makefile toggle only
- no libhv/OpenSSL/static-linking changes in this PR
