### PR TITLE
fix(pi-deps): adapt turbojpeg lib for Ubuntu 20.04 armhf compatibility

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -933,8 +933,23 @@ install_runtime_deps() {
     # GPU libs are needed for DRM+EGL hardware-accelerated rendering on Pi
     # libturbojpeg0: SIMD-accelerated JPEG decode for camera MJPEG streams
     # Note: OpenSSL is statically linked for Pi builds, no runtime libssl needed
-    local deps="libdrm2 libinput10 libgbm1 libegl1 libgles2 libturbojpeg0"
+    local deps="libdrm2 libinput10 libgbm1 libegl1 libgles2"
     local missing=""
+    local turbo_lib=""
+    local turbo_candidates="libturbojpeg0 libturbojpeg0-dev"
+    
+    for candidate in $turbo_candidates; do
+        # Check if package is installed or available in apt repo
+        if dpkg-query -W -f='${Status}' "$candidate" 2>/dev/null | grep -q "install ok installed" || \
+           apt-cache show "$candidate" 2>/dev/null | grep -q "^Package: $candidate$"; then
+            turbo_lib="$candidate"
+            log_info "Selected turbojpeg library: $candidate"
+            break
+        fi
+    done
+    
+    # Add selected turbojpeg library to dependencies list
+    [ -n "$turbo_lib" ] && deps="$deps $turbo_lib"
 
     for dep in $deps; do
         # Check if package is installed (dpkg-query returns 0 if installed)


### PR DESCRIPTION
Fix libturbojpeg0 installation failure on Ubuntu 20.04 armhf platform

### Changes
- Replace hardcoded libturbojpeg0 dependency with dynamic detection logic
- Add fallback to libturbojpeg0-dev for Ubuntu 20.04 armhf (no standalone libturbojpeg0)
- Keep minimal code changes to preserve original script behavior
- Ensure compatibility with all Pi platforms (pi/pi32) including Debian/Raspberry Pi OS

### Why
Ubuntu 20.04 armhf does not have a standalone libturbojpeg0 package (runtime libs are bundled in libturbojpeg0-dev), leading to installation errors. This change dynamically selects the correct turbojpeg library based on system availability.

### Testing
- Verified on Raspberry Pi OS (Bookworm) → uses libturbojpeg0
- Verified on Ubuntu 20.04 armhf → uses libturbojpeg0-dev
- Verified on Ubuntu 22.04 armhf → uses libturbojpeg0``


