### PR TITLE
fix(service): prevent double-restart on self-update

### DIFF
--- a/config/helixscreen.service
+++ b/config/helixscreen.service
@@ -36,10 +36,17 @@ Group=@@HELIX_GROUP@@
 # Working directory for config/assets
 WorkingDirectory=@@INSTALL_DIR@@
 
-# Pause update watcher during startup to prevent ExecStartPre side-effects
-# (e.g., chown changing ctime on release_info.json) from triggering a
-# spurious restart via helixscreen-update.path → helixscreen-update.service.
-ExecStartPre=+/bin/sh -c '/bin/systemctl stop helixscreen-update.path 2>/dev/null || true'
+# Cancel any pending update-watcher restart during startup.
+#
+# During a self-update, install.sh writes release_info.json which triggers
+# helixscreen-update.path → helixscreen-update.service (10s sleep then restart).
+# The app also calls _exit(0) after install, so systemd's Restart=always fires
+# immediately — giving two restarts.  Stopping both units here cancels the pending
+# oneshot if it's still sleeping, eliminating the second restart.
+#
+# For Moonraker web-type updates the oneshot has already completed its ExecStart
+# by the time helixscreen restarts, so stopping it here is a harmless no-op.
+ExecStartPre=+/bin/sh -c '/bin/systemctl stop helixscreen-update.path helixscreen-update.service 2>/dev/null || true'
 
 # Stop firmware display-management services that conflict with HelixScreen.
 # Creality SonicPad/Nebula ships display-sleep.sh which kills the backlight


### PR DESCRIPTION
## Summary

On-screen (in-app) upgrades caused HelixScreen to restart **twice** — once from `systemd`'s `Restart=always` after `_exit(0)`, and again ~9 seconds later from `helixscreen-update.service`.

## Root Cause

During a self-update, `install.sh` writes `release_info.json` to the install directory. This triggers `helixscreen-update.path` → `helixscreen-update.service`, which begins a `10s` sleep before restarting the service.

Meanwhile, after `install.sh` exits, `update_checker.cpp` calls `_exit(0)`. systemd's `Restart=always` fires immediately — **restart #1**.

The existing `ExecStartPre` in `helixscreen.service` stopped `helixscreen-update.path`, but **not** `helixscreen-update.service`, which was already running (sleeping). Stopping a path unit does not cancel an already-triggered oneshot.

## Journal Evidence (V0.2, 0.98.10 → 0.98.12)

| Time     | Event |
|----------|-------|
| 13:27:12 | `do_install()` forks `install.sh` (pid=1468) |
| 13:27:17 | `helixscreen-update.service` starts — `release_info.json` written during extraction; begins 10s `ExecStartPre` sleep |
| 13:27:18 | `install.sh` exits (code=0); `_exit(0)` called |
| 13:27:21 | **Restart #1** — `systemd` `Restart=always` (`RestartSec=3`, pid=1681) |
| 13:27:27 | **Restart #2** — `helixscreen-update.service` wakes, runs `systemctl restart helixscreen` (pid=1764) |

## Fix

Add `helixscreen-update.service` to the `ExecStartPre` stop command so the pending oneshot is cancelled when helixscreen restarts from a self-update:

```diff
-ExecStartPre=+/bin/sh -c '/bin/systemctl stop helixscreen-update.path 2>/dev/null || true'
+ExecStartPre=+/bin/sh -c '/bin/systemctl stop helixscreen-update.path helixscreen-update.service 2>/dev/null || true'
```

For Moonraker web-type updates, `helixscreen-update.service` has already completed its `ExecStart` by the time helixscreen restarts, so stopping it is a harmless no-op — Moonraker updates are unaffected.

## ⚠️ Deployment Note

This fix is in `config/helixscreen.service` (the template). The deployed `/etc/systemd/system/helixscreen.service` on existing installs is **not updated by self-updates** (intentionally preserved to retain platform customisations).

The fix will be deployed automatically on:
- **Fresh installs** via `install.sh`
- **Moonraker web-type updates** — `helixscreen-update.service`'s `ExecStartPre` copies the new template to `/etc/systemd/system/` and runs `daemon-reload`

Existing installs can apply it manually:
```bash
sudo cp ~/helixscreen/config/helixscreen.service /etc/systemd/system/helixscreen.service
sudo systemctl daemon-reload
```