### PR TITLE
fix(service): move update template logic to script to survive Moonraker extraction

### DIFF
--- a/config/helixscreen-update.service
+++ b/config/helixscreen-update.service
@@ -19,22 +19,12 @@ Description=Restart HelixScreen after update
 Type=oneshot
 ExecStartPre=/bin/sleep 10
 
-# Refresh main service file from the newly extracted install dir.
-# Picks up new directives (e.g. StateDirectory) that self-updates
-# can't apply due to NoNewPrivileges.  Runs as root (no User= set).
-ExecStartPre=/bin/sh -c '\
-  SRC="@@INSTALL_DIR@@/config/helixscreen.service"; \
-  DEST="/etc/systemd/system/helixscreen.service"; \
-  if [ -f "$$SRC" ] && [ -f "$$DEST" ]; then \
-    USER=$$(grep "^User=" "$$DEST" | cut -d= -f2); \
-    GROUP=$$(grep "^Group=" "$$DEST" | cut -d= -f2); \
-    WDIR=$$(grep "^WorkingDirectory=" "$$DEST" | cut -d= -f2); \
-    IDIR=$$(dirname "$$(dirname "$$SRC")"); \
-    cp "$$SRC" "$$DEST"; \
-    PDIR=$$(dirname "$$IDIR"); \
-    sed -i "s|@@HELIX_USER@@|$${USER:-root}|g; s|@@HELIX_GROUP@@|$${GROUP:-root}|g; s|@@INSTALL_DIR@@|$${IDIR}|g; s|@@INSTALL_PARENT@@|$${PDIR}|g" "$$DEST"; \
-    systemctl daemon-reload; \
-  fi'
+# Refresh systemd units from the newly extracted install dir.
+# The template logic lives in a script so Moonraker's extraction
+# updates it — avoids the chicken-and-egg where the installer's
+# sed pass corrupts @@placeholder@@ patterns embedded in this unit.
+# Runs as root (no User= set).
+ExecStartPre=@@INSTALL_DIR@@/config/refresh-service-units.sh
 
 ExecStart=/bin/systemctl restart helixscreen
 ExecStartPost=/bin/systemctl restart helixscreen-update.path

--- a/config/helixscreen.service
+++ b/config/helixscreen.service
@@ -44,8 +44,10 @@ WorkingDirectory=@@INSTALL_DIR@@
 # immediately — giving two restarts.  Stopping both units here cancels the pending
 # oneshot if it's still sleeping, eliminating the second restart.
 #
-# For Moonraker web-type updates the oneshot has already completed its ExecStart
-# by the time helixscreen restarts, so stopping it here is a harmless no-op.
+# For Moonraker web-type updates the oneshot's ExecStart (systemctl restart
+# helixscreen) is still running when this fires — stopping it kills the client
+# process, but systemd's job manager already has the restart queued so it
+# proceeds.  The ExecStartPost below re-arms the path unit afterward.
 ExecStartPre=+/bin/sh -c '/bin/systemctl stop helixscreen-update.path helixscreen-update.service 2>/dev/null || true'
 
 # Stop firmware display-management services that conflict with HelixScreen.

--- a/config/refresh-service-units.sh
+++ b/config/refresh-service-units.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Refresh systemd unit files from newly extracted install dir templates.
+#
+# Called by helixscreen-update.service after Moonraker extracts a new release.
+# This script lives in the install dir (not /etc/systemd/system/) so Moonraker's
+# extraction always updates it — solving the chicken-and-egg where the installer's
+# global sed pass would corrupt @@placeholder@@ patterns embedded directly in the
+# systemd unit file.
+#
+# Reads User/Group from the CURRENTLY installed helixscreen.service before
+# overwriting, then templates all @@placeholders@@ in the new copies.
+# Also refreshes the watcher units (update.service + update.path) so future
+# Moonraker updates pick up any fixes to the watcher mechanism itself.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+IDIR="$(dirname "$SCRIPT_DIR")"
+PDIR="$(dirname "$IDIR")"
+
+DEST="/etc/systemd/system/helixscreen.service"
+
+# Nothing to do if main service isn't installed
+[ -f "$DEST" ] || exit 0
+
+# Read current identity from the installed service file BEFORE overwriting
+USER_VAL="$(grep "^User=" "$DEST" | cut -d= -f2)"
+GROUP_VAL="$(grep "^Group=" "$DEST" | cut -d= -f2)"
+
+template_unit() {
+    local src="$1" dest="$2"
+    cp "$src" "$dest" || return 1
+    sed -i \
+        -e "s|@@HELIX_USER@@|${USER_VAL:-root}|g" \
+        -e "s|@@HELIX_GROUP@@|${GROUP_VAL:-root}|g" \
+        -e "s|@@INSTALL_DIR@@|${IDIR}|g" \
+        -e "s|@@INSTALL_PARENT@@|${PDIR}|g" \
+        "$dest"
+}
+
+# Refresh main service
+SRC="${IDIR}/config/helixscreen.service"
+[ -f "$SRC" ] && template_unit "$SRC" "$DEST"
+
+# Refresh watcher units (this service + path unit)
+for F in helixscreen-update.service helixscreen-update.path; do
+    FSRC="${IDIR}/config/${F}"
+    FDEST="/etc/systemd/system/${F}"
+    [ -f "$FSRC" ] && template_unit "$FSRC" "$FDEST"
+done
+
+systemctl daemon-reload

--- a/scripts/lib/installer/service.sh
+++ b/scripts/lib/installer/service.sh
@@ -186,8 +186,9 @@ install_update_watcher_systemd() {
     $SUDO cp "$path_src" "$path_dest"
     $SUDO cp "$svc_src" "$svc_dest"
 
-    # Template the install directory path
+    # Template the install directory path in both units
     _sed_inplace "s|@@INSTALL_DIR@@|${install_dir}|g" "$path_dest"
+    _sed_inplace "s|@@INSTALL_DIR@@|${install_dir}|g" "$svc_dest"
 
     $SUDO systemctl daemon-reload
     $SUDO systemctl enable helixscreen-update.path 2>/dev/null || true

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -162,6 +162,10 @@ package_platform() {
     # Copy config files
     cp "${PROJECT_DIR}/config/helixscreen.init" "$pkg_dir/config/"
     cp "${PROJECT_DIR}/config/helixscreen.service" "$pkg_dir/config/"
+    cp "${PROJECT_DIR}/config/helixscreen-update.service" "$pkg_dir/config/"
+    cp "${PROJECT_DIR}/config/helixscreen-update.path" "$pkg_dir/config/"
+    cp "${PROJECT_DIR}/config/refresh-service-units.sh" "$pkg_dir/config/"
+    chmod +x "$pkg_dir/config/refresh-service-units.sh"
     cp "${PROJECT_DIR}/config/printer_database.json" "$pkg_dir/config/" 2>/dev/null || true
     cp "${PROJECT_DIR}/config/printing_tips.json" "$pkg_dir/config/" 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

- Moonraker web-type updates failed to restart helixscreen because the installer's global sed pass corrupted `@@HELIX_USER@@` patterns inside `helixscreen-update.service`'s own sed command — the patterns became literal values (e.g. `pi`) that couldn't match `@@placeholders@@` in new templates, leaving `User=@@HELIX_USER@@` in the installed unit file
- Moves template substitution logic from inline `ExecStartPre` to `config/refresh-service-units.sh` — this script lives in the install dir so Moonraker's extraction always replaces it, breaking the chicken-and-egg
- The script also refreshes the watcher units themselves (update.service + update.path) from new templates, so future Moonraker updates pick up mechanism fixes
- Includes update.service, update.path, and refresh script in release packages
- Adds missing `@@INSTALL_DIR@@` substitution for service unit in installer
- Fixes incorrect comment about Moonraker update timing in helixscreen.service

## Test plan

- [ ] Fresh install: verify `helixscreen-update.service` in `/etc/systemd/system/` has `refresh-service-units.sh` call (not inline sed)
- [ ] Moonraker update: verify `refresh-service-units.sh` correctly templates all units and helixscreen restarts with new version
- [ ] Self-update (on-screen): verify no double restart — `ExecStartPre` kills update.service during sleep before script runs
- [ ] Verify release package includes `config/helixscreen-update.service`, `config/helixscreen-update.path`, `config/refresh-service-units.sh`