### PR TITLE
Cross docker build updates

### DIFF
--- a/mk/cross.mk
+++ b/mk/cross.mk
@@ -44,7 +44,8 @@
 # NPROC_DOCKER_RUN: Number of parallel jobs for Docker builds
 # Capped at 8 to prevent resource exhaustion in containerized environments
 # Can be overridden via environment variable: NPROC_DOCKER_RUN=<value>
-NPROC_DOCKER_RUN ?= $(shell echo $$(($(NPROC) > 8 ? 8 : $(NPROC))))
+_NPROC_HOST := $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+NPROC_DOCKER_RUN ?= $(shell echo $$(($(_NPROC_HOST) > 8 ? 8 : $(_NPROC_HOST))))
 
 # =============================================================================
 # Target Platform Definitions


### PR DESCRIPTION
As I was running into cross-compile issue on my Mac, a series of fixes:

- Remove target architecture on most docker cross build (except x86 types) - Didn't see a reasons to use x86 when ARM arch can be natively supported: Fall to default docker unless mandatory
- Do not use nproc command for 'docker run' make: this may be missing (eg: Darwin) and NPROC is correctly setup
- Avoid resource exhaustion: Max NPROC to 8 for docker cross build via dedicated NPROC_DOCKER_RUN (based on NPROC)