### PR TITLE
fix(lvgl-font): All use of compressed fonts

### DIFF
--- a/lv_conf.h
+++ b/lv_conf.h
@@ -566,7 +566,7 @@
 #define LV_FONT_FMT_TXT_LARGE 0
 
 /*Enables/disables support for compressed fonts.*/
-#define LV_USE_FONT_COMPRESSED 0
+#define LV_USE_FONT_COMPRESSED 1
 
 /*Enable drawing placeholders when glyph dsc is not found*/
 #define LV_USE_FONT_PLACEHOLDER 1


### PR DESCRIPTION
Should fix "no fonts" on some panel like console - failing with:
[2026-04-01 10:18:50.096] [helix] [warning] [LVGL] [Warn]       (1033.961, +0)   lv_font_get_bitmap_fmt_txt: Compressed fonts is used but LV_USE_FONT_COMPRESSED is not enabled in lv_conf.h lv_font_fmt_txt.c:213
[2026-04-01 10:18:50.096] [helix] [warning] [LVGL] [Warn]       (1033.961, +0)   draw_letter_cb: Couldn't get the bitmap of a glyph lv_draw_sw_letter.c:174