### PR TITLE
feat(ui): Do not show save button for gcode_offset calib strategy

### DIFF
--- a/include/printer_motion_state.h
+++ b/include/printer_motion_state.h
@@ -10,6 +10,20 @@
 namespace helix {
 
 /**
+ * @brief Z-offset calibration strategy — determines gcode commands for calibration and save
+ *
+ * Different printers need different approaches to calibrate and persist Z-offset.
+ * ForgeX-mod printers use SET_GCODE_OFFSET (auto-persisted by mod macro).
+ * Standard Klipper uses PROBE_CALIBRATE -> ACCEPT -> SAVE_CONFIG.
+ * Endstop printers use Z_ENDSTOP_CALIBRATE -> ACCEPT -> SAVE_CONFIG.
+ */
+enum class ZOffsetCalibrationStrategy {
+    PROBE_CALIBRATE, ///< Standard Klipper: PROBE_CALIBRATE -> ACCEPT -> SAVE_CONFIG
+    GCODE_OFFSET,    ///< ForgeX mod: G28 -> move -> G1 adjustments -> SET_GCODE_OFFSET
+    ENDSTOP ///< Endstop: Z_ENDSTOP_CALIBRATE -> ACCEPT -> Z_OFFSET_APPLY_ENDSTOP -> SAVE_CONFIG
+};
+
+/**
  * @brief Manages motion-related subjects for printer state
  *
  * Extracted from PrinterState as part of god class decomposition.
@@ -105,6 +119,24 @@ class PrinterMotionState {
     bool has_pending_z_offset_adjustment() const;
     void clear_pending_z_offset_delta();
 
+    /**
+     * @brief Get computed subject for save Z-offset button visibility
+     *
+     * Returns 1 when button should be visible (strategy != GCODE_OFFSET AND gcode_z_offset != 0).
+     * Use with bind_flag_if_eq in XML: hidden="true" + ref_value="0" = visible when subject is 1.
+     */
+    lv_subject_t* get_z_offset_save_button_visible_subject() {
+        return &z_offset_save_button_visible_;
+    }
+
+    /**
+     * @brief Update the save button visibility subject
+     *
+     * Called when either z_offset_calibration_strategy or gcode_z_offset changes.
+     * Button is visible (1) when strategy != GCODE_OFFSET AND gcode_z_offset != 0.
+     */
+    void update_z_offset_save_button_visibility(ZOffsetCalibrationStrategy strategy);
+
   private:
     friend class PrinterMotionStateTestAccess;
 
@@ -129,13 +161,14 @@ class PrinterMotionState {
     lv_subject_t flow_factor_{};
 
     // Actual speed/velocity subjects
-    lv_subject_t gcode_speed_{};              // mm/s (from gcode_move.speed)
-    lv_subject_t max_velocity_{};             // mm/s (from toolhead.max_velocity)
-    lv_subject_t live_extruder_velocity_{};   // centimm/s (from motion_report, ×100 for precision)
+    lv_subject_t gcode_speed_{};            // mm/s (from gcode_move.speed)
+    lv_subject_t max_velocity_{};           // mm/s (from toolhead.max_velocity)
+    lv_subject_t live_extruder_velocity_{}; // centimm/s (from motion_report, ×100 for precision)
 
     // Z-offset subjects
     lv_subject_t gcode_z_offset_{};
     lv_subject_t pending_z_offset_delta_{};
+    lv_subject_t z_offset_save_button_visible_{}; // Computed: 1 if visible
 };
 
 } // namespace helix

--- a/include/printer_state.h
+++ b/include/printer_state.h
@@ -141,20 +141,6 @@ enum class PrintStartPhase {
 };
 
 /**
- * @brief Z-offset calibration strategy — determines gcode commands for calibration and save
- *
- * Different printers need different approaches to calibrate and persist Z-offset.
- * ForgeX-mod printers use SET_GCODE_OFFSET (auto-persisted by mod macro).
- * Standard Klipper uses PROBE_CALIBRATE -> ACCEPT -> SAVE_CONFIG.
- * Endstop printers use Z_ENDSTOP_CALIBRATE -> ACCEPT -> SAVE_CONFIG.
- */
-enum class ZOffsetCalibrationStrategy {
-    PROBE_CALIBRATE, ///< Standard Klipper: PROBE_CALIBRATE -> ACCEPT -> SAVE_CONFIG
-    GCODE_OFFSET,    ///< ForgeX mod: G28 -> move -> G1 adjustments -> SET_GCODE_OFFSET
-    ENDSTOP ///< Endstop: Z_ENDSTOP_CALIBRATE -> ACCEPT -> Z_OFFSET_APPLY_ENDSTOP -> SAVE_CONFIG
-};
-
-/**
  * @brief Convert PrintJobState enum to display string
  *
  * Returns a human-readable string for UI display.
@@ -863,6 +849,16 @@ class PrinterState {
     }
 
     /**
+     * @brief Get computed subject for save Z-offset button visibility
+     *
+     * Returns 1 when button should be visible (strategy != GCODE_OFFSET AND gcode_z_offset != 0).
+     * Use with bind_flag_if_eq in XML: hidden="true" + ref_value="0" = visible when subject is 1.
+     */
+    lv_subject_t* get_z_offset_save_button_visible_subject() {
+        return motion_state_.get_z_offset_save_button_visible_subject();
+    }
+
+    /**
      * @brief Clear pending Z-offset delta (after save or dismiss)
      */
     void clear_pending_z_offset_delta() {
@@ -1254,8 +1250,8 @@ class PrinterState {
      * @param snapshot_url Snapshot URL of first enabled webcam
      */
     void set_webcam_available(bool available, const std::string& stream_url = "",
-                              const std::string& snapshot_url = "",
-                              bool flip_h = false, bool flip_v = false);
+                              const std::string& snapshot_url = "", bool flip_h = false,
+                              bool flip_v = false);
 
     /// Get MJPEG stream URL of first enabled webcam
     const std::string& get_webcam_stream_url() const {
@@ -1684,7 +1680,9 @@ class PrinterState {
      * String subject holding the human-readable name of the active printer.
      * Use with bind_text in XML to display the current printer name.
      */
-    lv_subject_t* get_active_printer_name_subject() { return &active_printer_name_; }
+    lv_subject_t* get_active_printer_name_subject() {
+        return &active_printer_name_;
+    }
 
     /**
      * @brief Get the multi-printer enabled subject
@@ -1692,7 +1690,9 @@ class PrinterState {
      * Integer subject: 1 when multiple printers are configured, 0 otherwise.
      * Use with bind_flag_if_eq in XML to show/hide multi-printer UI elements.
      */
-    lv_subject_t* get_multi_printer_enabled_subject() { return &multi_printer_enabled_; }
+    lv_subject_t* get_multi_printer_enabled_subject() {
+        return &multi_printer_enabled_;
+    }
 
     /**
      * @brief Set the active printer display name

--- a/src/printer/printer_motion_state.cpp
+++ b/src/printer/printer_motion_state.cpp
@@ -50,6 +50,8 @@ void PrinterMotionState::init_subjects(bool register_xml) {
                      register_xml); // Z-offset in microns from homing_origin[2]
     INIT_SUBJECT_INT(pending_z_offset_delta, 0, subjects_,
                      register_xml); // Accumulated adjustment during print
+    INIT_SUBJECT_INT(z_offset_save_button_visible, 0, subjects_,
+                     register_xml); // Computed: 1 if save button should be visible
 
     subjects_initialized_ = true;
     spdlog::trace("[PrinterMotionState] Subjects initialized successfully");
@@ -169,8 +171,7 @@ void PrinterMotionState::update_from_status(const nlohmann::json& status) {
     if (status.contains("motion_report")) {
         const auto& mr = status["motion_report"];
         if (mr.contains("live_extruder_velocity") && mr["live_extruder_velocity"].is_number()) {
-            int vel_centimm =
-                static_cast<int>(mr["live_extruder_velocity"].get<double>() * 100.0);
+            int vel_centimm = static_cast<int>(mr["live_extruder_velocity"].get<double>() * 100.0);
             if (lv_subject_get_int(&live_extruder_velocity_) != vel_centimm) {
                 lv_subject_set_int(&live_extruder_velocity_, vel_centimm);
             }
@@ -203,6 +204,17 @@ void PrinterMotionState::clear_pending_z_offset_delta() {
         spdlog::info("[PrinterMotionState] Clearing pending Z-offset delta");
         lv_subject_set_int(&pending_z_offset_delta_, 0);
     }
+}
+
+void PrinterMotionState::update_z_offset_save_button_visibility(
+    ZOffsetCalibrationStrategy strategy) {
+    // Button visible when: strategy != GCODE_OFFSET (1) AND gcode_z_offset != 0
+    int z_offset = lv_subject_get_int(&gcode_z_offset_);
+    int visible = (strategy != ZOffsetCalibrationStrategy::GCODE_OFFSET && z_offset != 0) ? 1 : 0;
+    lv_subject_set_int(&z_offset_save_button_visible_, visible);
+    spdlog::trace(
+        "[PrinterMotionState] Z-offset save button visible: {} (strategy={}, z_offset={})", visible,
+        static_cast<int>(strategy), z_offset);
 }
 
 } // namespace helix

--- a/src/printer/printer_state.cpp
+++ b/src/printer/printer_state.cpp
@@ -319,6 +319,9 @@ void PrinterState::update_from_status(const json& state) {
     // Delegate motion updates to motion state component
     motion_state_.update_from_status(state);
 
+    // Update save button visibility when gcode_z_offset changes
+    motion_state_.update_z_offset_save_button_visibility(z_offset_calibration_strategy_);
+
     // Delegate print updates to print state component
     print_domain_.update_from_status(state);
 
@@ -376,14 +379,15 @@ void PrinterState::update_from_status(const json& state) {
         if (eo.contains("objects") && eo["objects"].is_array()) {
             std::vector<PrinterExcludedObjectsState::ObjectInfo> objects;
             for (const auto& obj : eo["objects"]) {
-                if (!obj.is_object() || !obj.contains("name")) continue;
+                if (!obj.is_object() || !obj.contains("name"))
+                    continue;
 
                 PrinterExcludedObjectsState::ObjectInfo info;
                 info.name = obj["name"].get<std::string>();
 
                 if (obj.contains("center") && obj["center"].is_array() &&
-                    obj["center"].size() >= 2 &&
-                    obj["center"][0].is_number() && obj["center"][1].is_number()) {
+                    obj["center"].size() >= 2 && obj["center"][0].is_number() &&
+                    obj["center"][1].is_number()) {
                     info.center.x = obj["center"][0].get<float>();
                     info.center.y = obj["center"][1].get<float>();
                     info.has_center = true;
@@ -398,8 +402,8 @@ void PrinterState::update_from_status(const json& state) {
                     float max_x = std::numeric_limits<float>::lowest();
                     float max_y = max_x;
                     for (const auto& pt : obj["polygon"]) {
-                        if (pt.is_array() && pt.size() >= 2 &&
-                            pt[0].is_number() && pt[1].is_number()) {
+                        if (pt.is_array() && pt.size() >= 2 && pt[0].is_number() &&
+                            pt[1].is_number()) {
                             float x = pt[0].get<float>(), y = pt[1].get<float>();
                             info.polygon.push_back({x, y});
                             min_x = std::min(min_x, x);
@@ -467,7 +471,6 @@ void PrinterState::update_from_status(const json& state) {
     helix::sensors::AccelSensorManager::instance().update_from_status(state);
     helix::sensors::ColorSensorManager::instance().update_from_status(state);
     helix::sensors::TemperatureSensorManager::instance().update_from_status(state);
-
 }
 
 void PrinterState::reset_for_new_print() {
@@ -558,8 +561,8 @@ void PrinterState::set_hardware(const helix::PrinterDiscovery& hardware) {
         chamber_heater = "";
     }
 
-    spdlog::debug("[PrinterState] Chamber resolved: sensor='{}' heater='{}'",
-                  chamber_sensor, chamber_heater);
+    spdlog::debug("[PrinterState] Chamber resolved: sensor='{}' heater='{}'", chamber_sensor,
+                  chamber_heater);
     temperature_state_.set_chamber_sensor_name(chamber_sensor);
     temperature_state_.set_chamber_heater_name(chamber_heater);
 
@@ -621,8 +624,7 @@ void PrinterState::set_spoolman_available(bool available) {
 }
 
 void PrinterState::set_webcam_available(bool available, const std::string& stream_url,
-                                        const std::string& snapshot_url,
-                                        bool flip_h, bool flip_v) {
+                                        const std::string& snapshot_url, bool flip_h, bool flip_v) {
     // Delegate to capabilities_state_ component (handles thread-safety)
     capabilities_state_.set_webcam_available(available, stream_url, snapshot_url, flip_h, flip_v);
 }
@@ -804,9 +806,8 @@ void PrinterState::set_printer_type_internal(const std::string& type) {
     } else if (strategy_str == "probe_calibrate") {
         new_strategy = ZOffsetCalibrationStrategy::PROBE_CALIBRATE;
     } else {
-        new_strategy = capabilities_state_.has_probe()
-                           ? ZOffsetCalibrationStrategy::PROBE_CALIBRATE
-                           : ZOffsetCalibrationStrategy::ENDSTOP;
+        new_strategy = capabilities_state_.has_probe() ? ZOffsetCalibrationStrategy::PROBE_CALIBRATE
+                                                       : ZOffsetCalibrationStrategy::ENDSTOP;
     }
 
     if (type == printer_type_ && new_strategy == z_offset_calibration_strategy_) {
@@ -816,6 +817,9 @@ void PrinterState::set_printer_type_internal(const std::string& type) {
     printer_type_ = type;
     print_start_capabilities_ = new_caps;
     z_offset_calibration_strategy_ = new_strategy;
+
+    // Update save button visibility when strategy changes
+    motion_state_.update_z_offset_save_button_visibility(new_strategy);
 
     // Apply probe type override from database (e.g., prtouch_v2 for K1 series)
     std::string probe_type_str = PrinterDetector::get_probe_type(type);

--- a/ui_xml/controls_panel.xml
+++ b/ui_xml/controls_panel.xml
@@ -84,11 +84,11 @@
             <icon src="chevron_right" size="xs" variant="secondary"/>
           </lv_obj>
         </lv_obj>
-        <!-- Save Z-Offset button (conditional: visible when gcode_z_offset != 0, disabled during print) -->
+        <!-- Save Z-Offset button (visible when strategy != GCODE_OFFSET AND gcode_z_offset != 0) -->
         <ui_button name="btn_save_z_offset"
                    width="100%" height="#button_height_sm" variant="success" icon="check" text="Save Z-Offset"
                    translation_tag="Save Z-Offset" hidden="true">
-          <bind_flag_if_eq subject="gcode_z_offset" flag="hidden" ref_value="0"/>
+          <bind_flag_if_eq subject="z_offset_save_button_visible" flag="hidden" ref_value="0"/>
           <bind_state_if_eq subject="print_active" state="disabled" ref_value="1"/>
           <event_cb trigger="clicked" callback="on_controls_save_z_offset"/>
         </ui_button>

--- a/ui_xml/micro/controls_panel.xml
+++ b/ui_xml/micro/controls_panel.xml
@@ -84,11 +84,11 @@
             <icon src="chevron_right" size="xs" variant="secondary"/>
           </lv_obj>
         </lv_obj>
-        <!-- Save Z-Offset button (conditional: visible when gcode_z_offset != 0, disabled during print) -->
+        <!-- Save Z-Offset button (visible when strategy != GCODE_OFFSET AND gcode_z_offset != 0) -->
         <ui_button name="btn_save_z_offset"
                    width="100%" height="#button_height_sm" variant="success" icon="check" text="Save Z-Offset"
                    translation_tag="Save Z-Offset" hidden="true">
-          <bind_flag_if_eq subject="gcode_z_offset" flag="hidden" ref_value="0"/>
+          <bind_flag_if_eq subject="z_offset_save_button_visible" flag="hidden" ref_value="0"/>
           <bind_state_if_eq subject="print_active" state="disabled" ref_value="1"/>
           <event_cb trigger="clicked" callback="on_controls_save_z_offset"/>
         </ui_button>


### PR DESCRIPTION
Do not show save button on position for printer with z_offset_calibration_strategy being gcode_offset