### PR TITLE
Screen UX adjustement: fix for display issues seen on micro

### DIFF
--- a/ui_xml/components/temp_card_unified.xml
+++ b/ui_xml/components/temp_card_unified.xml
@@ -25,7 +25,7 @@
                     bind_current="extruder_temp" bind_target="extruder_target" flex_grow="1"
                     clickable="false" event_bubble="true"/>
       <text_small name="nozzle_status" bind_text="print_nozzle_status"
-                  style_text_align="right" style_min_width="70" variant="muted"
+                  style_text_align="right" style_min_width="50" variant="muted"
                   clickable="false" event_bubble="true"/>
     </lv_obj>
 
@@ -45,7 +45,7 @@
                     bind_current="bed_temp" bind_target="bed_target" flex_grow="1"
                     clickable="false" event_bubble="true"/>
       <text_small name="bed_status" bind_text="print_bed_status"
-                  style_text_align="right" style_min_width="70" variant="muted"
+                  style_text_align="right" style_min_width="50" variant="muted"
                   clickable="false" event_bubble="true"/>
     </lv_obj>
 
@@ -67,7 +67,7 @@
                     bind_current="chamber_temp" bind_target="chamber_target" flex_grow="1"
                     clickable="false" event_bubble="true"/>
       <text_small name="chamber_status" bind_text="print_chamber_status"
-                  style_text_align="right" style_min_width="70" variant="muted"
+                  style_text_align="right" style_min_width="50" variant="muted"
                   clickable="false" event_bubble="true"/>
     </lv_obj>
 

--- a/ui_xml/filament_panel.xml
+++ b/ui_xml/filament_panel.xml
@@ -45,7 +45,7 @@
                   height="content" style_pad_all="0" scrollable="false"
                   flex_flow="row" style_flex_main_place="start" style_flex_cross_place="center" style_pad_gap="#space_sm">
             <icon src="thermometer" size="sm" variant="secondary"/>
-            <text_body text="Temperatures" translation_tag="Temperatures" text_transform="uppercase" style_translate_y="2"/>
+            <text_body text="Temperature" translation_tag="Temperature" text_transform="uppercase" style_translate_y="2"/>
           </lv_obj>
 
           <!-- Nozzle Row: Current / Target (entire row tappable) -->
@@ -280,8 +280,8 @@
               flex_flow="column" style_pad_gap="#space_sm">
         <!-- Filament Operations Header -->
         <text_body text="Operations" translation_tag="Operations" text_transform="uppercase" align="left_mid">
-           <!-- Text label for MEDIUM+ breakpoints -->
-          <bind_flag_if_lt subject="ui_breakpoint" flag="hidden" ref_value="2"/>
+            <!-- Text label for TINY+ breakpoints -->
+            <bind_flag_if_lt subject="ui_breakpoint" flag="hidden" ref_value="1"/>
         </text_body>
         <!-- Load/Unload/Purge Row (macro-based, no length selector) -->
         <lv_obj width="100%"

--- a/ui_xml/filament_panel.xml
+++ b/ui_xml/filament_panel.xml
@@ -45,7 +45,7 @@
                   height="content" style_pad_all="0" scrollable="false"
                   flex_flow="row" style_flex_main_place="start" style_flex_cross_place="center" style_pad_gap="#space_sm">
             <icon src="thermometer" size="sm" variant="secondary"/>
-            <text_body text="Temperature" translation_tag="Temperature" text_transform="uppercase" style_translate_y="2"/>
+            <text_body text="Temperatures" translation_tag="Temperatures" text_transform="uppercase" style_translate_y="2"/>
           </lv_obj>
 
           <!-- Nozzle Row: Current / Target (entire row tappable) -->
@@ -279,7 +279,10 @@
               width="100%" height="content" style_pad_all="0" scrollable="false"
               flex_flow="column" style_pad_gap="#space_sm">
         <!-- Filament Operations Header -->
-        <text_body text="Operations" translation_tag="Operations" text_transform="uppercase" align="left_mid"/>
+        <text_body text="Operations" translation_tag="Operations" text_transform="uppercase" align="left_mid">
+           <!-- Text label for MEDIUM+ breakpoints -->
+          <bind_flag_if_lt subject="ui_breakpoint" flag="hidden" ref_value="2"/>
+        </text_body>
         <!-- Load/Unload/Purge Row (macro-based, no length selector) -->
         <lv_obj width="100%"
                 height="#button_height" style_pad_all="0" scrollable="false"

--- a/ui_xml/micro/controls_panel.xml
+++ b/ui_xml/micro/controls_panel.xml
@@ -128,7 +128,7 @@
             <lv_obj width="100%"
                     height="content" flex_flow="row" style_flex_cross_place="center" style_pad_all="0"
                     style_pad_gap="#space_sm" scrollable="false">
-              <icon src="heater" size="sm" variant="primary"/>
+              <icon src="thermometer" size="sm" variant="secondary"/>
               <text_small text="Temperatures"
                           translation_tag="Temperatures" style_translate_y="2" style_text_color="#text"/>
             </lv_obj>
@@ -143,7 +143,6 @@
                       style_flex_cross_place="center" style_pad_gap="#space_xs" clickable="false" event_bubble="true">
                 <icon name="nozzle_heater_icon"
                       src="heater" size="xs" variant="secondary" clickable="false" event_bubble="true"/>
-                <text_small bind_text="controls_nozzle_label"/>
                 <temp_display name="nozzle_temp_display"
                               size="md" show_target="true" bind_current="extruder_temp" bind_target="extruder_target"
                               clickable="false" event_bubble="true"/>
@@ -173,7 +172,6 @@
                       style_flex_cross_place="center" style_pad_gap="#space_xs" clickable="false" event_bubble="true">
                 <icon name="bed_heater_icon"
                       src="radiator" size="xs" variant="secondary" clickable="false" event_bubble="true"/>
-                <text_small text="Bed" translation_tag="Bed"/>
                 <temp_display name="bed_temp_display"
                               size="md" show_target="true" bind_current="bed_temp" bind_target="bed_target"
                               clickable="false" event_bubble="true"/>
@@ -201,7 +199,6 @@
                       height="content" flex_flow="row" style_pad_all="0" scrollable="false"
                       style_flex_cross_place="center" style_pad_gap="#space_xs" clickable="false" event_bubble="true">
                 <icon src="fridge_industrial" size="xs" variant="secondary" clickable="false" event_bubble="true"/>
-                <text_small text="Chamb:" translation_tag="Chamb:" clickable="false" event_bubble="true"/>
                 <temp_display name="chamber_temp_display"
                               size="md" show_target="true" bind_current="chamber_temp" bind_target="chamber_target"
                               clickable="false" event_bubble="true"/>


### PR DESCRIPTION
some fixes for display issues seen on micro - should not hurt other.

Note: 
I hide Operations title on filament panel based on ui_breakpoint.
On micro, cool down button would overlap that title

This impact TINY as this is the lowest break point (but higher)
==> I am checking to add a MICRO ui_breakpoint but this requires some renumbering / getting some regressions so likely not today