### PR TITLE
fix(update): 2min is not enought on slow printer and update will fail

### DIFF
--- a/src/system/update_checker.cpp
+++ b/src/system/update_checker.cpp
@@ -1381,7 +1381,8 @@ void UpdateChecker::do_install(const std::string& tarball_path) {
             if (log_fd >= 0)
                 close(log_fd);
 
-            constexpr int timeout_seconds = 120;
+            // Wait up to 10min
+            constexpr int timeout_seconds = 600;
             int status = 0;
             bool exited = false;
 


### PR DESCRIPTION
My Artillery M1 will needs around 5min to perform an update (not under load)
[2026-04-15 05:48:11.471] [helix] [info] [UpdateChecker] install.sh (pid=4669) exited after ~281s

In order to avoid timeout on slow printer, raising to 10min to avoid slow systems to get killed for being slow - especially since process check child pid => this is more of a "Hail Mary" fail-safe  ?