### PR TITLE
feat(build): ad5m-br mode + make install for kmod native variant (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to HelixScreen will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Build:** New `PLATFORM_TARGET=ad5m-br` mode and `make install DESTDIR=...`
+  target, enabling external build systems (starting with the AD5M Klipper Mod
+  firmware) to package HelixScreen as a native variant. See
+  `docs/devel/AD5M_KMOD_VARIANT.md`. The existing `ad5m` target is unchanged.
+
 ## [0.99.38] - 2026-04-20
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1031,9 +1031,12 @@ install:
 		install -m 0755 "$(BIN_DIR)/helix-watchdog" "$(DESTDIR)/opt/helixscreen/bin/helix-watchdog"; \
 	fi
 	@echo "  → binaries"
-	@# ui_xml: copy tree as-is (loaded at runtime)
+	@# ui_xml: copy tree, then prune source-tree build scaffolding that isn't runtime data.
 	@install -d "$(DESTDIR)/opt/helixscreen/ui_xml"
 	@cp -a ui_xml/. "$(DESTDIR)/opt/helixscreen/ui_xml/"
+	@find "$(DESTDIR)/opt/helixscreen/ui_xml" \
+		\( -name '*.c' -o -name '*.h' -o -name 'CMakeLists.txt' -o -name '*.cmake' \) \
+		-type f -delete
 	@echo "  → ui_xml/"
 	@# assets: fonts, images, sounds, config
 	@install -d "$(DESTDIR)/opt/helixscreen/assets"

--- a/Makefile
+++ b/Makefile
@@ -741,7 +741,7 @@ TRACKER_CXXFLAGS :=
 ifneq (,$(filter pi pi-fbdev pi-both pi32 pi32-fbdev pi32-both x86 x86-fbdev x86-both,$(PLATFORM_TARGET)))
     SOUND_CXXFLAGS := -DHELIX_HAS_SOUND
     TRACKER_CXXFLAGS := -DHELIX_HAS_TRACKER
-else ifneq (,$(filter ad5m ad5x,$(PLATFORM_TARGET)))
+else ifneq (,$(filter ad5m ad5m-br ad5x,$(PLATFORM_TARGET)))
     # AD5M/AD5X: PWM buzzer for tone-mode SFX only.
     # Tracker (MOD/MED) DISABLED — the PCM render thread's busy-wait loop
     # starves the single-core CPU, killing active prints and blocking

--- a/Makefile
+++ b/Makefile
@@ -822,7 +822,7 @@ MOCK_OBJS := $(patsubst $(TEST_MOCK_DIR)/%.cpp,$(OBJ_DIR)/tests/mocks/%.o,$(MOCK
 # Default target
 .DEFAULT_GOAL := all
 
-.PHONY: all build clean run test tests test-integration test-cards test-print-select test-size-content demo compile_commands compile_commands_full libhv-build apply-patches generate-fonts validate-fonts regen-fonts update-mdi-cache verify-mdi-codepoints help check-deps install-deps venv-setup icon format format-staged screenshots tools moonraker-inspector strict quality setup translations symbols strip dev
+.PHONY: all build clean run test tests test-integration test-cards test-print-select test-size-content demo compile_commands compile_commands_full libhv-build apply-patches generate-fonts validate-fonts regen-fonts update-mdi-cache verify-mdi-codepoints help check-deps install-deps venv-setup icon format format-staged screenshots tools moonraker-inspector strict quality setup translations symbols strip dev install
 
 # Fast development build: -O0 skips optimization passes (~2x faster compilation)
 # Library code still builds at -O2 (via SUBMODULE_CFLAGS) since it rarely changes
@@ -985,3 +985,67 @@ print-target-cflags:
 	@echo "$(TARGET_CFLAGS)"
 print-cxxflags:
 	@echo "$(CXXFLAGS)"
+
+# =============================================================================
+# Install target — stages binary + assets under $(DESTDIR)/opt/helixscreen/
+#
+# Used by external buildroot/yocto/debian packaging (e.g. kmod's helixscreen.mk).
+# DESTDIR is mandatory; no system-wide install supported (by design — HelixScreen
+# runs as a dedicated embedded UI, not a general-purpose package).
+#
+# Layout:
+#   $(DESTDIR)/opt/helixscreen/
+#     bin/          helix-screen, helix-splash, helix-watchdog (if built)
+#     ui_xml/       runtime XML layouts (components, panels, translations)
+#     assets/
+#       fonts/      (only tiers enabled for this platform)
+#       images/     LVGL bitmaps, SVGs
+#       sounds/     platform-compatible sounds
+#       config/     default printer database, presets, platform hooks
+#     certs/        ca-certificates.crt (for HTTPS, if bundled)
+#
+# Runtime writable state (config, cache, logs) is NOT installed. Init scripts
+# create /data/helixscreen/{config,cache,log}/ on first boot.
+# =============================================================================
+.PHONY: install
+install:
+	@if [ -z "$(DESTDIR)" ]; then \
+		echo "$(RED)error: DESTDIR is required (e.g. make install DESTDIR=/tmp/staging)$(RESET)" >&2; \
+		exit 1; \
+	fi
+	@if [ -z "$(BUILD_SUBDIR)" ]; then \
+		echo "$(RED)error: PLATFORM_TARGET must be set (e.g. PLATFORM_TARGET=ad5m-br)$(RESET)" >&2; \
+		exit 1; \
+	fi
+	@if [ ! -x "$(BIN_DIR)/helix-screen" ]; then \
+		echo "$(RED)error: $(BIN_DIR)/helix-screen not found — run '$(MAKE) PLATFORM_TARGET=$(PLATFORM_TARGET)' first$(RESET)" >&2; \
+		exit 1; \
+	fi
+	@echo "$(BOLD)Installing to $(DESTDIR)/opt/helixscreen/$(RESET)"
+	@install -d "$(DESTDIR)/opt/helixscreen/bin"
+	@install -m 0755 "$(BIN_DIR)/helix-screen" "$(DESTDIR)/opt/helixscreen/bin/helix-screen"
+	@if [ -x "$(BIN_DIR)/helix-splash" ]; then \
+		install -m 0755 "$(BIN_DIR)/helix-splash" "$(DESTDIR)/opt/helixscreen/bin/helix-splash"; \
+	fi
+	@if [ -x "$(BIN_DIR)/helix-watchdog" ]; then \
+		install -m 0755 "$(BIN_DIR)/helix-watchdog" "$(DESTDIR)/opt/helixscreen/bin/helix-watchdog"; \
+	fi
+	@echo "  → binaries"
+	@# ui_xml: copy tree as-is (loaded at runtime)
+	@install -d "$(DESTDIR)/opt/helixscreen/ui_xml"
+	@cp -a ui_xml/. "$(DESTDIR)/opt/helixscreen/ui_xml/"
+	@echo "  → ui_xml/"
+	@# assets: fonts, images, sounds, config
+	@install -d "$(DESTDIR)/opt/helixscreen/assets"
+	@if [ -d assets/fonts ]; then cp -a assets/fonts "$(DESTDIR)/opt/helixscreen/assets/"; fi
+	@if [ -d assets/images ]; then cp -a assets/images "$(DESTDIR)/opt/helixscreen/assets/"; fi
+	@if [ -d assets/sounds ]; then cp -a assets/sounds "$(DESTDIR)/opt/helixscreen/assets/"; fi
+	@if [ -d assets/config ]; then cp -a assets/config "$(DESTDIR)/opt/helixscreen/assets/"; fi
+	@echo "  → assets/"
+	@# certs (optional — only present after `make ad5m-docker` fetched them)
+	@if [ -f "$(BUILD_DIR)/certs/ca-certificates.crt" ]; then \
+		install -d "$(DESTDIR)/opt/helixscreen/certs"; \
+		install -m 0644 "$(BUILD_DIR)/certs/ca-certificates.crt" "$(DESTDIR)/opt/helixscreen/certs/"; \
+		echo "  → certs/"; \
+	fi
+	@echo "$(GREEN)Install complete: $(DESTDIR)/opt/helixscreen/$(RESET)"

--- a/Makefile
+++ b/Makefile
@@ -974,9 +974,11 @@ endif
 include mk/rules.mk
 
 # Debug helpers — print computed variables for bats tests.
-.PHONY: print-ldflags print-strip print-target-cflags print-cxxflags
+.PHONY: print-ldflags print-target-ldflags print-strip print-target-cflags print-cxxflags
 print-ldflags:
 	@echo "$(LDFLAGS)"
+print-target-ldflags:
+	@echo "$(TARGET_LDFLAGS)"
 print-strip:
 	@echo "STRIP_BINARY=$(STRIP_BINARY)"
 print-target-cflags:

--- a/Makefile
+++ b/Makefile
@@ -972,3 +972,14 @@ ifdef PI_DUAL_LINK
 include mk/pi-dual-link.mk
 endif
 include mk/rules.mk
+
+# Debug helpers — print computed variables for bats tests.
+.PHONY: print-ldflags print-strip print-target-cflags print-cxxflags
+print-ldflags:
+	@echo "$(LDFLAGS)"
+print-strip:
+	@echo "STRIP_BINARY=$(STRIP_BINARY)"
+print-target-cflags:
+	@echo "$(TARGET_CFLAGS)"
+print-cxxflags:
+	@echo "$(CXXFLAGS)"

--- a/assets/config/presets/cc1.json
+++ b/assets/config/presets/cc1.json
@@ -2,6 +2,8 @@
   "preset": "cc1",
   "wizard_completed": false,
   "display": {
+    "rotate": 0,
+    "rotation_probed": true,
     "backlight_enable_ioctl": false,
     "hardware_blank": 0,
     "sleep_backlight_off": false,
@@ -46,8 +48,16 @@
       "selected_strips": ["led case", "led hotend"]
     },
     "filament_sensors": {
+      "_comment": "CC1 has a physical filament switch on the chassis wired to main MCU pin PC0 (active-low). Stock COSMOS firmware does not yet declare a Klipper section for it; OpenCentauri/cosmos PR #152 proposes '[filament_switch_sensor filament_sensor]' and is the expected name once merged. Until then this entry binds to nothing and the UI shows the sensor as offline.",
       "master_enabled": true,
-      "sensors": []
+      "sensors": [
+        {
+          "enabled": true,
+          "klipper_name": "filament_switch_sensor filament_sensor",
+          "role": "runout",
+          "type": "switch"
+        }
+      ]
     },
     "hardware": {
       "expected": [
@@ -57,7 +67,10 @@
         "heater_fan extruder",
         "fan_generic model_helper_fan",
         "fan_generic box_fan",
+        "temperature_fan mainboard",
         "temperature_sensor box",
+        "temperature_sensor mcu_toolhead",
+        "temperature_sensor mcu_bed",
         "led case",
         "led hotend",
         "load_cell_probe"

--- a/assets/config/presets/k1c.json
+++ b/assets/config/presets/k1c.json
@@ -23,10 +23,11 @@
       "hotend": "heater_fan hotend_fan",
       "chamber": "temperature_fan chamber_fan",
       "exhaust": "output_pin fan1",
+      "aux": "output_pin fan2",
       "names": {
         "output_pin fan0": "Part",
         "output_pin fan1": "Chamber Exhaust",
-        "output_pin fan2": "Aux Bed"
+        "output_pin fan2": "Auxiliary"
       }
     },
     "leds": {
@@ -70,8 +71,8 @@
     },
     "default_macros": {
       "cooldown": "SET_HEATER_TEMPERATURE HEATER=extruder TARGET=0\nSET_HEATER_TEMPERATURE HEATER=heater_bed TARGET=0",
-      "load_filament": { "label": "Load", "gcode": "LOAD_FILAMENT" },
-      "unload_filament": { "label": "Unload", "gcode": "UNLOAD_FILAMENT" },
+      "load_filament": { "label": "Load", "gcode": "LOAD_MATERIAL" },
+      "unload_filament": { "label": "Unload", "gcode": "QUIT_MATERIAL" },
       "macro_1": { "label": "Clean Nozzle", "gcode": "HELIX_CLEAN_NOZZLE" },
       "macro_2": { "label": "Bed Level", "gcode": "HELIX_BED_MESH_IF_NEEDED" }
     }

--- a/assets/config/presets/snapmaker-u1.json
+++ b/assets/config/presets/snapmaker-u1.json
@@ -23,7 +23,7 @@
     "fans": {
       "chamber": "",
       "exhaust": "",
-      "hotend": "heater_fan power_fan",
+      "hotend": "heater_fan e0_nozzle_fan",
       "part": "fan",
       "names": {
         "fan_generic cavity_fan": "Aux Bed Fan"
@@ -89,11 +89,11 @@
       ]
     },
     "default_macros": {
-      "cooldown": "SET_HEATER_TEMPERATURE HEATER=extruder TARGET=0\nSET_HEATER_TEMPERATURE HEATER=heater_bed TARGET=0",
-      "load_filament": { "label": "Load", "gcode": "LOAD_FILAMENT" },
-      "unload_filament": { "label": "Unload", "gcode": "UNLOAD_FILAMENT" },
-      "macro_1": { "label": "Clean Nozzle", "gcode": "HELIX_CLEAN_NOZZLE" },
-      "macro_2": { "label": "Bed Level", "gcode": "HELIX_BED_MESH_IF_NEEDED" }
+      "cooldown": "SET_HEATER_TEMPERATURE HEATER=extruder TARGET=0\nSET_HEATER_TEMPERATURE HEATER=extruder1 TARGET=0\nSET_HEATER_TEMPERATURE HEATER=extruder2 TARGET=0\nSET_HEATER_TEMPERATURE HEATER=extruder3 TARGET=0\nSET_HEATER_TEMPERATURE HEATER=heater_bed TARGET=0",
+      "load_filament": { "label": "Load", "gcode": "AUTO_FEEDING" },
+      "unload_filament": { "label": "Unload", "gcode": "INNER_FILAMENT_UNLOAD" },
+      "macro_1": { "label": "Clean Nozzle", "gcode": "ROUGHLY_CLEAN_NOZZLE" },
+      "macro_2": { "label": "Bed Mesh", "gcode": "BED_MESH_CALIBRATE" }
     },
     "panel_widgets": {
       "home": {

--- a/docs/devel/AD5M_KMOD_VARIANT.md
+++ b/docs/devel/AD5M_KMOD_VARIANT.md
@@ -1,0 +1,115 @@
+# AD5M Klipper Mod Native Variant
+
+HelixScreen can be built by the AD5M Klipper Mod firmware (xblax/flashforge_ad5m_klipper_mod)
+as a first-class variant alongside GuppyScreen and KlipperScreen. This doc
+explains the integration contract we provide upstream.
+
+## Two build modes for AD5M
+
+| Mode | Target | When to use |
+|---|---|---|
+| `ad5m` | ARM GCC 10.3 (bundled via Docker) + fully static | Our release flow. Sideload install onto ForgeX/zmod/kmod; produces a standalone tarball. |
+| `ad5m-br` | External cross-toolchain (buildroot / yocto / caller-provided) + dynamic linking | Consumed by an outer build system (kmod's buildroot package) that manages the toolchain and system libraries. |
+
+Both produce an armv7-a (Cortex-A7 hard-float) binary with identical functional
+behavior. `ad5m-br` trades binary size (static → dynamic) for integration
+simplicity with upstream distros.
+
+## What `ad5m-br` expects from the caller
+
+- `CROSS_COMPILE` prefix pointing at an armv7-a hard-float glibc toolchain
+  (buildroot's default: `arm-buildroot-linux-gnueabihf-`).
+- `CC`, `CXX`, `AR`, `RANLIB`, `STRIP` set to the full toolchain binaries (or
+  prefixed names resolvable via `PATH`).
+- A sysroot with `libssl`, `libcrypto`, `libstdc++`, `libpthread`, `libm`,
+  `libdl`, `libz`.
+- `libevdev` available at link time (for touch input — buildroot: `BR2_PACKAGE_LIBEVDEV=y`).
+
+What we build in-tree (not from sysroot): `libhv`, `spdlog`, `libnl-3`,
+`libnl-genl-3`, `libwpa_client`. These are pinned submodules with project-
+specific patches; using system versions would force incompatible version
+churn.
+
+## Invoking the build from an external tree
+
+```make
+# buildroot example (kmod's helixscreen.mk):
+define HELIXSCREEN_BUILD_CMDS
+    $(MAKE) $(TARGET_CONFIGURE_OPTS) PLATFORM_TARGET=ad5m-br -C $(@D)
+endef
+
+define HELIXSCREEN_INSTALL_TARGET_CMDS
+    $(MAKE) $(TARGET_CONFIGURE_OPTS) PLATFORM_TARGET=ad5m-br \
+        install DESTDIR=$(TARGET_DIR) -C $(@D)
+endef
+```
+
+`$(TARGET_CONFIGURE_OPTS)` is buildroot-provided; it expands to something like:
+`CC=arm-buildroot-linux-gnueabihf-gcc CXX=... AR=... RANLIB=... STRIP=... CFLAGS=...`
+
+## Install layout
+
+`make install DESTDIR=$(TARGET_DIR)` writes:
+
+```
+$(DESTDIR)/opt/helixscreen/
+├── bin/
+│   ├── helix-screen           # main binary (armv7-a)
+│   ├── helix-splash           # boot splash (optional)
+│   └── helix-watchdog         # crash recovery (optional)
+├── ui_xml/                    # runtime XML layouts
+├── assets/
+│   ├── fonts/                 # medium + large tier only for AD5M
+│   ├── images/
+│   ├── sounds/                # PWM-tone only on AD5M
+│   └── config/
+│       ├── printer_database.json
+│       ├── presets/{ad5m,ad5m_pro,ad5m_zmod,ad5m_pro_zmod}.json
+│       ├── print_start_profiles/ad5m.json
+│       └── platform/hooks-ad5m-kmod.sh
+└── certs/ca-certificates.crt  # only if built with `make ad5m-docker`
+```
+
+Runtime writable state (config file, log, cache) is **not** installed — the
+init script creates it under `/data/helixscreen/` on first boot.
+
+## How `data_root_resolver` finds everything
+
+`src/application/data_root_resolver.cpp` strips known suffixes (`/build/bin`,
+`/bin`) from the binary's argv[0] to discover the asset root. Installing to
+`/opt/helixscreen/bin/helix-screen` means the resolver strips `/bin` and lands
+at `/opt/helixscreen/`, where it finds `ui_xml/` — no env vars needed.
+
+## Testing locally
+
+```bash
+# Build + install into a staging dir using our Docker toolchain image
+# (close enough to buildroot's toolchain for verification)
+make docker-toolchain-ad5m
+
+STAGE=$(pwd)/build/ad5m-br-staging
+docker run --rm --user $(id -u):$(id -g) \
+  -v "$PWD":/src -w /src \
+  -e PATH=/opt/arm-toolchain/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+  -v "$HOME/.cache/helixscreen-ccache/ad5m-br":/ccache \
+  -e CCACHE_DIR=/ccache \
+  helixscreen/toolchain-ad5m \
+  sh -c 'make PLATFORM_TARGET=ad5m-br \
+         CROSS_COMPILE=arm-none-linux-gnueabihf- \
+         CC=arm-none-linux-gnueabihf-gcc CXX=arm-none-linux-gnueabihf-g++ \
+         AR=arm-none-linux-gnueabihf-ar RANLIB=arm-none-linux-gnueabihf-ranlib \
+         STRIP=arm-none-linux-gnueabihf-strip SKIP_OPTIONAL_DEPS=1 -j$(nproc) && \
+         make install PLATFORM_TARGET=ad5m-br DESTDIR=/src/build/ad5m-br-staging'
+
+# If running from a worktree, ALSO bind-mount the main repo path so symlinks resolve:
+#   -v /absolute/main/repo/path:/absolute/main/repo/path
+
+# Inspect
+find build/ad5m-br-staging/opt/helixscreen -maxdepth 2 -type d | sort
+```
+
+## Upstream integration (Phase 2 — separate plan)
+
+See `docs/superpowers/specs/2026-04-20-ad5m-kmod-native-variant-design.md` §
+"Phase 2: kmod variant wiring" for the buildroot package, variant defconfig,
+and overlay we'll submit to xblax/flashforge_ad5m_klipper_mod.

--- a/docs/devel/CLAUDE.md
+++ b/docs/devel/CLAUDE.md
@@ -69,6 +69,7 @@ All developer documentation lives here. When working on features, look up the re
 | `printers/SNAPMAKER_U1_SUPPORT.md` | Snapmaker U1 toolchanger platform |
 | `printers/CREALITY_K2_SUPPORT.md` | Creality K2 series platform |
 | `printers/FLASHFORGE_AD5X_SUPPORT.md` | FlashForge Adventurer 5X (MIPS, ZMOD) |
+| `AD5M_KMOD_VARIANT.md` | Building HelixScreen as a native variant inside the AD5M Klipper Mod firmware |
 | `ENVIRONMENT_VARIABLES.md` | All runtime and build env vars |
 
 ## Integration

--- a/mk/cross.mk
+++ b/mk/cross.mk
@@ -11,7 +11,8 @@
 #   make PLATFORM_TARGET=pi32-fbdev  # Cross-compile for Pi (armhf, fbdev fallback)
 #   make PLATFORM_TARGET=pi-both  # Pi 64-bit: compile once, link DRM + fbdev
 #   make PLATFORM_TARGET=pi32-both  # Pi 32-bit: compile once, link DRM + fbdev
-#   make PLATFORM_TARGET=ad5m  # Cross-compile for Adventurer 5M (armv7-a)
+#   make PLATFORM_TARGET=ad5m  # Cross-compile for Adventurer 5M (armv7-a, bundled toolchain)
+#   make PLATFORM_TARGET=ad5m-br # Adventurer 5M via buildroot-provided toolchain (kmod)
 #   make PLATFORM_TARGET=cc1   # Cross-compile for Centauri Carbon 1 (armv7-a)
 #   make PLATFORM_TARGET=mips  # Cross-compile for MIPS32 devices (K1)
 #   make PLATFORM_TARGET=k1    # Alias for mips (Creality K1 series)
@@ -247,6 +248,36 @@ else ifeq ($(PLATFORM_TARGET),ad5m)
     BUILD_SUBDIR := ad5m
     # Strip binary for size on memory-constrained device
     STRIP_BINARY := yes
+    FONT_TIERS := medium large
+
+else ifeq ($(PLATFORM_TARGET),ad5m-br)
+    # -------------------------------------------------------------------------
+    # Flashforge Adventurer 5M - buildroot-compat variant for AD5M Klipper Mod
+    # integration. Parallels `ad5m` but:
+    #   - Expects CROSS_COMPILE from caller (buildroot's arm-buildroot-linux-gnueabihf-)
+    #   - No -static (buildroot links dynamically against its sysroot)
+    #   - No strip (buildroot strips target binaries itself)
+    #   - Dynamic OpenSSL (buildroot ships libssl; no static-link needed)
+    # All other CPU tuning, size optimizations, and asset gates match `ad5m`.
+    # -------------------------------------------------------------------------
+    # CROSS_COMPILE is NOT defaulted here — buildroot passes it via TARGET_CONFIGURE_OPTS.
+    TARGET_ARCH := armv7-a
+    TARGET_TRIPLE := arm-buildroot-linux-gnueabihf
+    TARGET_CFLAGS := -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -mtune=cortex-a7 \
+        -Os -flto -ffunction-sections -fdata-sections -funwind-tables \
+        -Wno-error=conversion -Wno-error=sign-conversion -DHELIX_RELEASE_BUILD -DHELIX_PLATFORM_AD5M \
+        -DHELIX_HAS_LABEL_PRINTER=0 -DHELIX_HAS_CFS=0 -DHELIX_HAS_IFS=0
+    # No -static — buildroot wants dynamic linking against its sysroot
+    TARGET_LDFLAGS := -Wl,--gc-sections -flto -lstdc++fs
+    ENABLE_SSL := yes
+    DISPLAY_BACKEND := fbdev
+    ENABLE_SDL := no
+    ENABLE_GLES_3D := no
+    ENABLE_SCREENSAVER := no
+    ENABLE_EVDEV := yes
+    BUILD_SUBDIR := ad5m-br
+    # No strip — buildroot strips target binaries itself
+    STRIP_BINARY := no
     FONT_TIERS := medium large
 
 else ifeq ($(PLATFORM_TARGET),ad5x)
@@ -601,7 +632,7 @@ else ifeq ($(PLATFORM_TARGET),native)
     BUILD_SUBDIR :=
 
 else
-    $(error Unknown PLATFORM_TARGET: $(PLATFORM_TARGET). Valid options: native, pi, pi32, x86, ad5m, cc1, mips, k1, ad5x, k1-dynamic, k2, snapmaker-u1, yocto)
+    $(error Unknown PLATFORM_TARGET: $(PLATFORM_TARGET). Valid options: native, pi, pi32, x86, ad5m, ad5m-br, cc1, mips, k1, ad5x, k1-dynamic, k2, snapmaker-u1, yocto)
 endif
 
 # =============================================================================

--- a/mk/cross.mk
+++ b/mk/cross.mk
@@ -814,7 +814,7 @@ endif
 # Cross-Compilation Build Targets
 # =============================================================================
 
-.PHONY: pi pi-both pi32 pi32-both ad5m cc1 mips k1 ad5x k1-dynamic k2 snapmaker-u1 x86 x86-both pi-docker pi32-docker ad5m-docker cc1-docker mips-docker k1-docker ad5x-docker k1-dynamic-docker k2-docker snapmaker-u1-docker x86-docker x86-fbdev-docker x86-all-docker docker-toolchains docker-toolchain-snapmaker-u1 docker-toolchain-x86 cross-info ensure-docker ensure-buildx maybe-stop-colima
+.PHONY: pi pi-both pi32 pi32-both ad5m ad5m-br cc1 mips k1 ad5x k1-dynamic k2 snapmaker-u1 x86 x86-both pi-docker pi32-docker ad5m-docker cc1-docker mips-docker k1-docker ad5x-docker k1-dynamic-docker k2-docker snapmaker-u1-docker x86-docker x86-fbdev-docker x86-all-docker docker-toolchains docker-toolchain-snapmaker-u1 docker-toolchain-x86 cross-info ensure-docker ensure-buildx maybe-stop-colima
 
 # Persistent ccache for Docker builds — bind-mounts a host directory so the
 # cache survives across container runs (the container is --rm).  Per-platform

--- a/mk/deps.mk
+++ b/mk/deps.mk
@@ -259,7 +259,9 @@ install-deps:
 # Clean libhv build artifacts
 libhv-clean:
 	$(ECHO) "$(CYAN)Cleaning libhv build artifacts...$(RESET)"
-	$(Q)find $(LIBHV_DIR) -type f \( -name '*.o' -o -name '*.a' -o -name '*.so' -o -name '*.dylib' \) -delete 2>/dev/null || true
+	# -L follows symlinks so worktrees (where $(LIBHV_DIR) may be a symlink to
+	# the main repo's lib/libhv) also get their stale artifacts cleaned.
+	$(Q)find -L $(LIBHV_DIR) -type f \( -name '*.o' -o -name '*.a' -o -name '*.so' -o -name '*.dylib' \) -delete 2>/dev/null || true
 	$(Q)rm -f $(BUILD_DIR)/lib/libhv.a 2>/dev/null || true
 	$(ECHO) "$(GREEN)✓ libhv cleaned$(RESET)"
 
@@ -315,9 +317,13 @@ libhv-build:
 	$(Q)mkdir -p $(BUILD_DIR)/lib
 ifneq ($(CROSS_COMPILE),)
 	# Cross-compilation mode - ALWAYS clean first to avoid architecture mixing and stale artifacts
-	# This is critical: mixing native and cross-compiled objects causes subtle runtime bugs
+	# This is critical: mixing native and cross-compiled objects causes subtle runtime bugs.
+	# -L follows symlinks so worktrees (where $(LIBHV_DIR) may be a symlink to the main repo's
+	# lib/libhv) also get their stale artifacts cleaned - otherwise stale .o files from a prior
+	# toolchain can leak into the resulting libhv.a, producing link errors (e.g. undefined
+	# __time64/__localtime64 when a buildroot 12.3 hlog.o survives into a GCC-10 link).
 	$(Q)echo "$(YELLOW)→ Cleaning libhv for cross-compilation...$(RESET)"
-	$(Q)find $(LIBHV_DIR) -type f \( -name '*.o' -o -name '*.a' -o -name '*.so' -o -name '*.dylib' \) -delete 2>/dev/null || true
+	$(Q)find -L $(LIBHV_DIR) -type f \( -name '*.o' -o -name '*.a' -o -name '*.so' -o -name '*.dylib' \) -delete 2>/dev/null || true
 	# Pass cross-compiler to configure and make.
 	# When SSL is enabled, map target -> toolchain OpenSSL prefix.
 	$(Q)OPENSSL_PREFIX=""; \

--- a/tests/shell/test_ad5m_br_install.bats
+++ b/tests/shell/test_ad5m_br_install.bats
@@ -81,3 +81,18 @@ teardown() {
         return 1
     }
 }
+
+@test "install: ui_xml/ excludes source-tree build scaffolding" {
+    run make install PLATFORM_TARGET=ad5m-br DESTDIR="$STAGE_DIR"
+    [ "$status" -eq 0 ]
+    # None of these should appear under the installed ui_xml/ tree
+    ! find "$STAGE_DIR/opt/helixscreen/ui_xml" \
+        \( -name 'CMakeLists.txt' -o -name '*.cmake' -o -name '*.c' -o -name '*.h' \) \
+        -type f | grep -q . || {
+        echo "Unexpected source scaffolding shipped in install tree:"
+        find "$STAGE_DIR/opt/helixscreen/ui_xml" \
+            \( -name 'CMakeLists.txt' -o -name '*.cmake' -o -name '*.c' -o -name '*.h' \) \
+            -type f
+        return 1
+    }
+}

--- a/tests/shell/test_ad5m_br_install.bats
+++ b/tests/shell/test_ad5m_br_install.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Verify `make install DESTDIR=...` produces the expected /opt/helixscreen/ layout.
+# Uses a stub binary so we don't need a full cross-compile.
+
+load helpers
+
+STAGE_DIR=""
+
+setup() {
+    STAGE_DIR="$(mktemp -d)"
+    # Create stub binaries so install target doesn't fail on missing files
+    mkdir -p build/ad5m-br/bin
+    echo '#!/bin/sh' > build/ad5m-br/bin/helix-screen && chmod +x build/ad5m-br/bin/helix-screen
+    echo '#!/bin/sh' > build/ad5m-br/bin/helix-splash && chmod +x build/ad5m-br/bin/helix-splash
+}
+
+teardown() {
+    rm -rf "$STAGE_DIR"
+    rm -f build/ad5m-br/bin/helix-screen build/ad5m-br/bin/helix-splash
+}
+
+@test "install: produces /opt/helixscreen/bin/helix-screen" {
+    run make install PLATFORM_TARGET=ad5m-br DESTDIR="$STAGE_DIR"
+    [ "$status" -eq 0 ] || {
+        echo "install failed: $output"
+        return 1
+    }
+    [ -x "$STAGE_DIR/opt/helixscreen/bin/helix-screen" ]
+}
+
+@test "install: produces ui_xml/ tree" {
+    run make install PLATFORM_TARGET=ad5m-br DESTDIR="$STAGE_DIR"
+    [ "$status" -eq 0 ]
+    [ -d "$STAGE_DIR/opt/helixscreen/ui_xml" ]
+    [ -f "$STAGE_DIR/opt/helixscreen/ui_xml/globals.xml" ]
+}
+
+@test "install: produces assets/config/printer_database.json" {
+    run make install PLATFORM_TARGET=ad5m-br DESTDIR="$STAGE_DIR"
+    [ "$status" -eq 0 ]
+    [ -f "$STAGE_DIR/opt/helixscreen/assets/config/printer_database.json" ]
+}
+
+@test "install: includes AD5M kmod hook" {
+    run make install PLATFORM_TARGET=ad5m-br DESTDIR="$STAGE_DIR"
+    [ "$status" -eq 0 ]
+    [ -f "$STAGE_DIR/opt/helixscreen/assets/config/platform/hooks-ad5m-kmod.sh" ]
+}
+
+@test "install: data_root_resolver finds the installed tree" {
+    # With binary at /opt/helixscreen/bin/helix-screen, the resolver strips /bin
+    # and checks /opt/helixscreen/ui_xml. Verify that directory structure exists.
+    run make install PLATFORM_TARGET=ad5m-br DESTDIR="$STAGE_DIR"
+    [ "$status" -eq 0 ]
+    [ -d "$STAGE_DIR/opt/helixscreen/ui_xml" ]
+}
+
+@test "install: does NOT create writable state (config/, cache/, log/)" {
+    run make install PLATFORM_TARGET=ad5m-br DESTDIR="$STAGE_DIR"
+    [ "$status" -eq 0 ]
+    # Runtime state belongs under /data, not /opt — installer doesn't create it
+    [ ! -d "$STAGE_DIR/opt/helixscreen/config" ] || {
+        echo "Unexpected /opt/helixscreen/config/ in install output"
+        return 1
+    }
+    [ ! -d "$STAGE_DIR/opt/helixscreen/cache" ] || {
+        echo "Unexpected /opt/helixscreen/cache/ in install output"
+        return 1
+    }
+}
+
+@test "install: DESTDIR is mandatory — no install into system paths" {
+    # Without DESTDIR, must not touch /opt
+    run make install PLATFORM_TARGET=ad5m-br
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -qE 'DESTDIR.*required|missing DESTDIR|DESTDIR is required' || {
+        echo "Expected error about missing DESTDIR; got:"
+        echo "$output"
+        return 1
+    }
+}

--- a/tests/shell/test_ad5m_br_platform.bats
+++ b/tests/shell/test_ad5m_br_platform.bats
@@ -48,3 +48,45 @@ load helpers
         return 1
     }
 }
+
+@test "ad5m-br: sound enabled (HELIX_HAS_SOUND), tracker disabled" {
+    run make -n PLATFORM_TARGET=ad5m-br CROSS_COMPILE= CC=gcc CXX=g++ print-cxxflags
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q 'DHELIX_HAS_SOUND' || {
+        echo "Expected -DHELIX_HAS_SOUND in ad5m-br CXXFLAGS:"
+        echo "$output"
+        return 1
+    }
+    ! echo "$output" | grep -q 'DHELIX_HAS_TRACKER' || {
+        echo "Unexpected -DHELIX_HAS_TRACKER (should be off on ad5m-br):"
+        echo "$output"
+        return 1
+    }
+}
+
+@test "ad5m-br: no libusb" {
+    # Pass CROSS_COMPILE so the cross-target LDFLAGS branch fires and libusb
+    # filter is evaluated meaningfully.
+    run make -n PLATFORM_TARGET=ad5m-br CROSS_COMPILE=arm-buildroot-linux-gnueabihf- CC=gcc CXX=g++ print-ldflags
+    [ "$status" -eq 0 ]
+    ! echo "$output" | grep -qE '(^|[[:space:]"])-lusb-1\.0([[:space:]"]|$)' || {
+        echo "Unexpected -lusb-1.0 in ad5m-br LDFLAGS:"
+        echo "$output"
+        return 1
+    }
+}
+
+@test "ad5m-br: OpenSSL linked dynamically (no -Wl,-Bstatic -lssl)" {
+    run make -n PLATFORM_TARGET=ad5m-br CROSS_COMPILE=arm-buildroot-linux-gnueabihf- CC=gcc CXX=g++ print-ldflags
+    [ "$status" -eq 0 ]
+    ! echo "$output" | grep -qE -- '-Wl,-Bstatic[[:space:]]+-lssl' || {
+        echo "OpenSSL is statically linked in ad5m-br (should be dynamic):"
+        echo "$output"
+        return 1
+    }
+    echo "$output" | grep -qE -- '-lssl' || {
+        echo "Expected -lssl in ad5m-br LDFLAGS:"
+        echo "$output"
+        return 1
+    }
+}

--- a/tests/shell/test_ad5m_br_platform.bats
+++ b/tests/shell/test_ad5m_br_platform.bats
@@ -14,11 +14,11 @@ load helpers
     }
 }
 
-@test "ad5m-br: does NOT set -static in LDFLAGS" {
-    run make -n PLATFORM_TARGET=ad5m-br CROSS_COMPILE= CC=gcc CXX=g++ print-ldflags
+@test "ad5m-br: does NOT set -static in TARGET_LDFLAGS" {
+    run make -n PLATFORM_TARGET=ad5m-br CROSS_COMPILE= CC=gcc CXX=g++ print-target-ldflags
     [ "$status" -eq 0 ]
     ! echo "$output" | grep -qE '(^|\s)-static(\s|$)' || {
-        echo "Unexpected -static in ad5m-br LDFLAGS:"
+        echo "Unexpected -static in ad5m-br TARGET_LDFLAGS:"
         echo "$output"
         return 1
     }
@@ -37,7 +37,7 @@ load helpers
 @test "ad5m-br: inherits ad5m TARGET_CFLAGS cpu/fpu flags" {
     run make -n PLATFORM_TARGET=ad5m-br CROSS_COMPILE= CC=gcc CXX=g++ print-target-cflags
     [ "$status" -eq 0 ]
-    echo "$output" | grep -qE 'mcpu=cortex-a7|mtune=cortex-a7' || {
+    echo "$output" | grep -qE 'mtune=cortex-a7' || {
         echo "Missing cortex-a7 tuning in ad5m-br TARGET_CFLAGS:"
         echo "$output"
         return 1

--- a/tests/shell/test_ad5m_br_platform.bats
+++ b/tests/shell/test_ad5m_br_platform.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Verify PLATFORM_TARGET=ad5m-br is recognized by the Makefile and produces
+# the expected CFLAGS/LDFLAGS (no -static, no strip, toolchain-neutral).
+
+load helpers
+
+@test "ad5m-br: make accepts PLATFORM_TARGET=ad5m-br without unknown-target error" {
+    run make -n PLATFORM_TARGET=ad5m-br CROSS_COMPILE= CC=gcc CXX=g++ cross-info
+    [ "$status" -eq 0 ] || {
+        echo "stdout: $output"
+        return 1
+    }
+}
+
+@test "ad5m-br: does NOT set -static in LDFLAGS" {
+    run make -n PLATFORM_TARGET=ad5m-br CROSS_COMPILE= CC=gcc CXX=g++ print-ldflags
+    [ "$status" -eq 0 ]
+    ! echo "$output" | grep -qE '(^|\s)-static(\s|$)' || {
+        echo "Unexpected -static in ad5m-br LDFLAGS:"
+        echo "$output"
+        return 1
+    }
+}
+
+@test "ad5m-br: STRIP_BINARY is not yes" {
+    run make -n PLATFORM_TARGET=ad5m-br CROSS_COMPILE= CC=gcc CXX=g++ print-strip
+    [ "$status" -eq 0 ]
+    ! echo "$output" | grep -qE 'STRIP_BINARY=yes' || {
+        echo "Unexpected STRIP_BINARY=yes in ad5m-br:"
+        echo "$output"
+        return 1
+    }
+}
+
+@test "ad5m-br: inherits ad5m TARGET_CFLAGS cpu/fpu flags" {
+    run make -n PLATFORM_TARGET=ad5m-br CROSS_COMPILE= CC=gcc CXX=g++ print-target-cflags
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -qE 'mcpu=cortex-a7|mtune=cortex-a7' || {
+        echo "Missing cortex-a7 tuning in ad5m-br TARGET_CFLAGS:"
+        echo "$output"
+        return 1
+    }
+    echo "$output" | grep -qE 'mfpu=neon-vfpv4' || {
+        echo "Missing neon-vfpv4 in ad5m-br TARGET_CFLAGS:"
+        echo "$output"
+        return 1
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of making HelixScreen a native variant of the [AD5M Klipper Mod firmware](https://github.com/xblax/flashforge_ad5m_klipper_mod). Adds the build-system and packaging hooks an external buildroot tree needs to consume HelixScreen as a first-class variant alongside GuppyScreen and KlipperScreen.

- **What**: new `PLATFORM_TARGET=ad5m-br` build mode and `make install DESTDIR=...` target so external buildroot/yocto trees (starting with xblax/flashforge_ad5m_klipper_mod) can package HelixScreen.
- **Contract**: documented in \`docs/devel/AD5M_KMOD_VARIANT.md\`; drop-in \`HELIXSCREEN_BUILD_CMDS\` / \`HELIXSCREEN_INSTALL_TARGET_CMDS\` snippets for buildroot's \`\$(TARGET_CONFIGURE_OPTS)\`.
- **Difference from \`ad5m\`**: no \`-static\`, no self-strip, dynamic OpenSSL, caller-provided toolchain. All other AD5M-specific gates (cortex-a7 tuning, sound-without-tracker, no libusb, no label printer / CFS / IFS, fbdev) match.
- **Install layout**: relocatable \`/opt/helixscreen/{bin,ui_xml,assets,certs}/\` — \`data_root_resolver\` picks it up via its \`/bin\` suffix strip, no env vars required. Runtime writable state (\`config/\`, \`cache/\`, \`log/\`) deliberately not installed; init scripts create it under \`/data/helixscreen/\` on first boot.
- **Out of scope (Phase 2, separate PR)**: fork xblax/flashforge_ad5m_klipper_mod, add the buildroot package, variant defconfig, and overlay.

Spec: \`docs/superpowers/specs/2026-04-20-ad5m-kmod-native-variant-design.md\` (gitignored; local working doc).

## Test plan

- [x] \`bats tests/shell/test_ad5m_br_platform.bats\` (7/7 pass)
- [x] \`bats tests/shell/test_ad5m_br_install.bats\` (8/8 pass)
- [x] Docker cross-compile via \`helixscreen/toolchain-ad5m\` with \`PLATFORM_TARGET=ad5m-br\` produces a dynamically-linked armv7-a ELF (verified with \`file\` + \`readelf -d\`)
- [x] \`make install DESTDIR=/tmp/x\` produces the documented \`/opt/helixscreen/\` layout
- [x] Existing \`PLATFORM_TARGET=ad5m\` target unchanged (no regression on our Docker/sideload release flow)
- [ ] Smoke test on physical AD5M hardware — deferred to Phase 2 where we'll flash an actual kmod image