### PR TITLE
ci: skip scheduled workflows on forks via upstream gate job

### DIFF
--- a/.github/workflows/lvgl-tracker.yml
+++ b/.github/workflows/lvgl-tracker.yml
@@ -9,7 +9,15 @@ on:
   workflow_dispatch:      # Manual trigger for testing
 
 jobs:
+  gate:
+    name: Upstream gate
+    if: github.repository == 'prestonbrown/helixscreen'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Running on upstream repo"
+
   check-lvgl:
+    needs: gate
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,11 +16,19 @@ env:
   CXX: ccache clang++
 
 jobs:
+  gate:
+    name: Upstream gate
+    if: github.repository == 'prestonbrown/helixscreen'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Running on upstream repo"
+
   # ===========================================================================
   # Shared build step — produces binary + test binary as artifacts
   # ===========================================================================
   build:
     name: Build
+    needs: gate
     runs-on: ubuntu-22.04
     timeout-minutes: 180
 
@@ -199,6 +207,7 @@ jobs:
   # ===========================================================================
   test-shell:
     name: Shell Tests (BATS)
+    needs: gate
     runs-on: ubuntu-22.04
     timeout-minutes: 15
 
@@ -220,6 +229,7 @@ jobs:
   # ===========================================================================
   test-asan:
     name: AddressSanitizer
+    needs: gate
     runs-on: ubuntu-22.04
     timeout-minutes: 240
 
@@ -302,6 +312,7 @@ jobs:
   # ===========================================================================
   test-tsan:
     name: ThreadSanitizer
+    needs: gate
     runs-on: ubuntu-22.04
     timeout-minutes: 240
 
@@ -387,6 +398,7 @@ jobs:
   # ===========================================================================
   test-python:
     name: Python Tests
+    needs: gate
     runs-on: ubuntu-22.04
     timeout-minutes: 10
 
@@ -413,6 +425,7 @@ jobs:
   # ===========================================================================
   test-macos:
     name: macOS Tests
+    needs: gate
     runs-on: macos-14
     timeout-minutes: 120
 


### PR DESCRIPTION
I don't think forked repos should be running nightly and sub-module dependency scheduled jobs?

Gating the workflow runs to only run in the upsteam repo.