### PR TITLE
Revise QIDI model compatibility details in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ See [docs/devel/GALLERY.md](docs/devel/GALLERY.md) for the full gallery.
 | x86 Mini PC (Debian) | x86_64 | Tested |
 | macOS / Linux desktop | x86_64 / ARM64 | Development / CI |
 
-¹ QIDI models with Linux framebuffer displays (Q2, Plus 4, Max 4) only. Stock firmware runs standard Moonraker and works directly; community firmware like [FreeDi](https://github.com/Phil1988/FreeDi), [53Aries/Q2-Firmware](https://github.com/53Aries/Q2-Firmware), or [OpenQIDI](https://openqidi.com/) is optional. Older models (X-Max 3, X-Plus 3, Q1 Pro, X-Smart 3) use TJC/Nextion serial displays and are **not compatible** without a screen replacement.
+¹ QIDI models with Linux framebuffer displays (Q2, Max 4) only. Stock firmware runs standard Moonraker and works directly; community firmware like [FreeDi](https://github.com/Phil1988/FreeDi), [53Aries/Q2-Firmware](https://github.com/53Aries/Q2-Firmware), or [FreeQIDI](https://github.com/Phil1988/FreeQIDI) is optional. Older models (X-Smart 3, X-Plus 3, X-Max 3, Q1 Pro, Plus4) use TJC serial displays and are **not compatible** without a screen replacement.
 
 ² Elegoo Centauri Carbon requires the community [OpenCentauri COSMOS](https://github.com/OpenCentauri/cosmos) firmware ([docs](https://docs.opencentauri.cc/klipper-conversion/cosmos/cosmos/); stock Elegoo firmware has no SSH, Klipper, or Moonraker). Ships with factory white-balance calibration for the 4.3" panel.
 


### PR DESCRIPTION
Corrected supported QIDI printers (Plus4 has a TJC) and firmware sources (OpenQIDI is not a community firmware -> FreeQIDI is).