### PR TITLE
docs(qidi): update chamber heater limitation to MMU heater control

### DIFF
--- a/docs/devel/printers/QIDI_SUPPORT.md
+++ b/docs/devel/printers/QIDI_SUPPORT.md
@@ -224,7 +224,7 @@ HelixScreen ships a **Q2 Happy Hare preset** (`presets/qidi_q2.json`) for exactl
 - **Q2 resolution is very small** -- The Q2's 480x272 display uses the MICRO layout. Some UI elements may be cramped but the layout is functional.
 - **Q2 has limited RAM** -- ~498 MB total. HelixScreen must be memory-conscious on this device.
 - **Max 4 untested** -- Detection heuristics and display rendering for this model are based on specs. Community testers welcome.
-- **No MMU heater control UI** -- The Qidi Box has a dedicated MMU heater, but HelixScreen doesn't yet have a dedicated MMU heater control panel.
+- **No MMU heater control UI** -- The Qidi Box has a dedicated MMU heater, but HelixScreen doesn't yet have a dedicated MMU heater control panel. Note that the Happy Hare drying screen is a separate feature — it controls dryer heaters exposed through Happy Hare, not the native Qidi Box heater.
 
 ## Q2 Hardware Details
 

--- a/docs/devel/printers/QIDI_SUPPORT.md
+++ b/docs/devel/printers/QIDI_SUPPORT.md
@@ -224,7 +224,7 @@ HelixScreen ships a **Q2 Happy Hare preset** (`presets/qidi_q2.json`) for exactl
 - **Q2 resolution is very small** -- The Q2's 480x272 display uses the MICRO layout. Some UI elements may be cramped but the layout is functional.
 - **Q2 has limited RAM** -- ~498 MB total. HelixScreen must be memory-conscious on this device.
 - **Max 4 untested** -- Detection heuristics and display rendering for this model are based on specs. Community testers welcome.
-- **No mmu heater control UI** -- The Qidi Box has a dedicated heater, but HelixScreen doesn't yet have a dedicated MMU temp widget.
+- **No MMU heater control UI** -- The Qidi Box has a dedicated MMU heater, but HelixScreen doesn't yet have a dedicated MMU heater control panel.
 
 ## Q2 Hardware Details
 

--- a/docs/devel/printers/QIDI_SUPPORT.md
+++ b/docs/devel/printers/QIDI_SUPPORT.md
@@ -224,7 +224,7 @@ HelixScreen ships a **Q2 Happy Hare preset** (`presets/qidi_q2.json`) for exactl
 - **Q2 resolution is very small** -- The Q2's 480x272 display uses the MICRO layout. Some UI elements may be cramped but the layout is functional.
 - **Q2 has limited RAM** -- ~498 MB total. HelixScreen must be memory-conscious on this device.
 - **Max 4 untested** -- Detection heuristics and display rendering for this model are based on specs. Community testers welcome.
-- **No chamber heater control UI** -- QIDI printers have heated chambers, but HelixScreen doesn't yet have a dedicated chamber temperature control panel.
+- **No mmu heater control UI** -- The Qidi Box has a dedicated heater, but HelixScreen doesn't yet have a dedicated MMU temp widget.
 
 ## Q2 Hardware Details
 


### PR DESCRIPTION
## Summary

- Removes the outdated "No chamber heater control UI" limitation note for QIDI printers, since HelixScreen now has a chamber heater button
- Adds a new limitation noting the lack of a dedicated MMU heater widget for the Qidi Box's dedicated heater