### PR TITLE
docs: fix small mistake

### DIFF
--- a/docs/user/INSTALL.md
+++ b/docs/user/INSTALL.md
@@ -205,10 +205,10 @@ sh /usr/data/install.sh --local /usr/data/helixscreen-k1.zip
 
 Installs to `/usr/data/helixscreen/`, boot service at `/etc/init.d/S99helixscreen`.
 
-### Creality K2 Series
+### Creality  Series
 
 - **Hardware:**
-  - Creality K2 Max, K2 Plus, or K2 Pro
+  - Creality K2 Plus, or K2 Pro
   - Stock 4.3" touchscreen display (480x800)
   - Network connection
 

--- a/docs/user/INSTALL.md
+++ b/docs/user/INSTALL.md
@@ -205,7 +205,7 @@ sh /usr/data/install.sh --local /usr/data/helixscreen-k1.zip
 
 Installs to `/usr/data/helixscreen/`, boot service at `/etc/init.d/S99helixscreen`.
 
-### Creality  Series
+### Creality K2 Series
 
 - **Hardware:**
   - Creality K2 Plus, or K2 Pro


### PR DESCRIPTION
For some reason, an unreleased "K2 Max" was mentioned in the docs. This is just a small nitpick I noticed when skimming the docs. I can't tell if this is mentioning the base model K2, or this was overlooked.