### PR TITLE
Portrait layout foundation: min-dimension breakpoints + bottom-navbar shell

### DIFF
--- a/include/theme_manager.h
+++ b/include/theme_manager.h
@@ -261,11 +261,25 @@ void theme_manager_deinit();
  * Returns the suffix string used to select responsive variants from globals.xml.
  * Useful for testing and debugging responsive behavior.
  *
- * @param resolution Screen height (vertical resolution)
+ * @param resolution Screen dimension in pixels (typically responsive_dimension(display) —
+ *                   the smaller of width and height, so portrait orientations pick a
+ *                   breakpoint matched to the cramped axis).
  * @return "_tiny" (≤390), "_small" (391-460), "_medium" (461-550), "_large" (551-700), or "_xlarge"
  * (>700)
  */
 const char* theme_manager_get_breakpoint_suffix(int32_t resolution);
+
+/**
+ * @brief Return the smaller dimension of the display (width or height).
+ *
+ * Used for responsive breakpoint selection so portrait layouts pick a breakpoint
+ * suited to the cramped axis. Landscape: typically returns height. Portrait:
+ * returns width. Pass nullptr to use the default display.
+ *
+ * @param display LVGL display instance, or nullptr for the default display
+ * @return min(horizontal_resolution, vertical_resolution), or 600 as a safe fallback
+ */
+int32_t responsive_dimension(lv_display_t* display);
 
 /**
  * @brief Register responsive spacing tokens (space_* system)

--- a/src/ui/theme_manager.cpp
+++ b/src/ui/theme_manager.cpp
@@ -44,22 +44,37 @@ static int tier_num_for_suffix(const char* suffix) {
     return -1;
 }
 
+// Returns the smaller dimension of the display — used for responsive breakpoint
+// selection so portrait layouts pick a breakpoint suited to the cramped axis.
+// Landscape: typically the height. Portrait: the width. Either way, the short
+// dimension is the one the design system has to fit content into.
+int32_t responsive_dimension(lv_display_t* display) {
+    lv_display_t* d = display ? display : lv_display_get_default();
+    if (!d)
+        return 600; // safe fallback when no display is available
+    int32_t hor = lv_display_get_horizontal_resolution(d);
+    int32_t ver = lv_display_get_vertical_resolution(d);
+    if (hor <= 0 || ver <= 0)
+        return 600;
+    return hor < ver ? hor : ver;
+}
+
 // Breakpoint ladder — keep in sync with theme_manager_get_breakpoint_suffix()
-// and FONT_TIERS ordering. Shared between init (theme_manager_init) and
-// rotation refresh (theme_manager_refresh_layout_constants) so both paths
-// select the same breakpoint for a given vertical resolution.
-static UiBreakpoint compute_breakpoint_from_height(int32_t ver_res) {
-    if (ver_res <= UI_BREAKPOINT_MICRO_MAX)
+// and FONT_TIERS ordering. The resolution argument is the dimension the design
+// system should adapt to — typically responsive_dimension(display) so both
+// orientations pick a breakpoint matched to the cramped axis.
+static UiBreakpoint compute_breakpoint(int32_t resolution) {
+    if (resolution <= UI_BREAKPOINT_MICRO_MAX)
         return UiBreakpoint::Micro;
-    if (ver_res <= UI_BREAKPOINT_TINY_MAX)
+    if (resolution <= UI_BREAKPOINT_TINY_MAX)
         return UiBreakpoint::Tiny;
-    if (ver_res <= UI_BREAKPOINT_SMALL_MAX)
+    if (resolution <= UI_BREAKPOINT_SMALL_MAX)
         return UiBreakpoint::Small;
-    if (ver_res <= UI_BREAKPOINT_MEDIUM_MAX)
+    if (resolution <= UI_BREAKPOINT_MEDIUM_MAX)
         return UiBreakpoint::Medium;
-    if (ver_res <= UI_BREAKPOINT_LARGE_MAX)
+    if (resolution <= UI_BREAKPOINT_LARGE_MAX)
         return UiBreakpoint::Large;
-    if (ver_res <= UI_BREAKPOINT_XLARGE_MAX)
+    if (resolution <= UI_BREAKPOINT_XLARGE_MAX)
         return UiBreakpoint::XLarge;
     return UiBreakpoint::XXLarge;
 }
@@ -409,9 +424,8 @@ static void update_handle_styles(const theme_palette_t* palette, int border_radi
     } else {
         // Responsive knob padding: smaller at tiny/micro to avoid clipping in compact cards
         auto* display = lv_display_get_default();
-        auto bp = display
-                      ? compute_breakpoint_from_height(lv_display_get_vertical_resolution(display))
-                      : UiBreakpoint::Medium;
+        auto bp =
+            display ? compute_breakpoint(responsive_dimension(display)) : UiBreakpoint::Medium;
         int32_t knob_pad = (bp <= UiBreakpoint::Tiny) ? LV_DPX(4) : LV_DPX(6);
         lv_style_set_pad_left(&slider_knob_style, knob_pad);
         lv_style_set_pad_right(&slider_knob_style, knob_pad);
@@ -661,9 +675,8 @@ static void helix_theme_apply(lv_theme_t* theme, lv_obj_t* obj) {
  * @brief Resolve border radius pixels from size index + current display breakpoint.
  */
 static int resolve_border_radius(const helix::ThemeProperties& props) {
-    int32_t ver_res =
-        theme_display ? lv_display_get_vertical_resolution(theme_display) : 600; // safe fallback
-    const char* suffix = theme_manager_get_breakpoint_suffix(ver_res);
+    int32_t resp_res = responsive_dimension(theme_display);
+    const char* suffix = theme_manager_get_breakpoint_suffix(resp_res);
     return helix::BorderRadiusSizes::pixels(props.border_radius_size, suffix);
 }
 
@@ -854,7 +867,7 @@ static void theme_manager_register_static_constants(lv_xml_component_scope_t* sc
 /**
  * Get the breakpoint suffix for a given resolution
  *
- * Breakpoints (ver_res in px) — ranges come from UI_BREAKPOINT_*_MAX constants:
+ * Breakpoints (in px) — ranges come from UI_BREAKPOINT_*_MAX constants:
  *   "_micro"    (≤ MICRO_MAX,   e.g. 272)
  *   "_tiny"     (≤ TINY_MAX,    e.g. 320)
  *   "_small"    (≤ SMALL_MAX,   e.g. 460)
@@ -863,7 +876,9 @@ static void theme_manager_register_static_constants(lv_xml_component_scope_t* sc
  *   "_xlarge"   (≤ XLARGE_MAX, e.g. 1280)
  *   "_xxlarge"  (> XLARGE_MAX — 1440p / 4K)
  *
- * @param resolution Screen height (vertical resolution)
+ * @param resolution Screen dimension in px — typically responsive_dimension(display)
+ *                   so portrait orientations pick a breakpoint matched to the
+ *                   cramped axis.
  * @return One of the seven suffix strings above (valid for lv_xml_get_const lookups).
  */
 const char* theme_manager_get_breakpoint_suffix(int32_t resolution) {
@@ -900,15 +915,17 @@ void theme_manager_register_responsive_spacing(lv_display_t* display) {
     int32_t hor_res = lv_display_get_horizontal_resolution(display);
     int32_t ver_res = lv_display_get_vertical_resolution(display);
 
-    // Use screen height for breakpoint selection — vertical space is the constraint
-    const char* size_suffix = theme_manager_get_breakpoint_suffix(ver_res);
-    const char* size_label = (ver_res <= UI_BREAKPOINT_MICRO_MAX)    ? "MICRO"
-                             : (ver_res <= UI_BREAKPOINT_TINY_MAX)   ? "TINY"
-                             : (ver_res <= UI_BREAKPOINT_SMALL_MAX)  ? "SMALL"
-                             : (ver_res <= UI_BREAKPOINT_MEDIUM_MAX) ? "MEDIUM"
-                             : (ver_res <= UI_BREAKPOINT_LARGE_MAX)  ? "LARGE"
-                             : (ver_res <= UI_BREAKPOINT_XLARGE_MAX) ? "XLARGE"
-                                                                     : "XXLARGE";
+    // Use the smaller dimension — the cramped axis is the design constraint
+    // regardless of orientation (landscape: usually height; portrait: width).
+    int32_t resp_res = hor_res < ver_res ? hor_res : ver_res;
+    const char* size_suffix = theme_manager_get_breakpoint_suffix(resp_res);
+    const char* size_label = (resp_res <= UI_BREAKPOINT_MICRO_MAX)    ? "MICRO"
+                             : (resp_res <= UI_BREAKPOINT_TINY_MAX)   ? "TINY"
+                             : (resp_res <= UI_BREAKPOINT_SMALL_MAX)  ? "SMALL"
+                             : (resp_res <= UI_BREAKPOINT_MEDIUM_MAX) ? "MEDIUM"
+                             : (resp_res <= UI_BREAKPOINT_LARGE_MAX)  ? "LARGE"
+                             : (resp_res <= UI_BREAKPOINT_XLARGE_MAX) ? "XLARGE"
+                                                                      : "XXLARGE";
 
     lv_xml_component_scope_t* scope = lv_xml_component_get_scope("globals");
     if (!scope) {
@@ -1019,8 +1036,8 @@ void theme_manager_register_responsive_spacing(lv_display_t* display) {
         }
     }
 
-    spdlog::trace("[Theme] Responsive spacing: {} (height={}px) - auto-registered {} tokens",
-                  size_label, ver_res, registered);
+    spdlog::trace("[Theme] Responsive spacing: {} (min_dim={}px) - auto-registered {} tokens",
+                  size_label, resp_res, registered);
 
     // ========================================================================
     // Register computed overlay widths (derived from nav_width + gap)
@@ -1077,8 +1094,10 @@ void theme_manager_refresh_layout_constants(lv_display_t* display) {
         lv_xml_update_const(scope, "nav_width", nav_it->second.c_str());
     }
 
-    // Update all responsive spacing tokens for new breakpoint
-    const char* size_suffix = theme_manager_get_breakpoint_suffix(ver_res);
+    // Update all responsive spacing tokens for new breakpoint (use min dimension
+    // so portrait orientations pick a breakpoint suited to the cramped axis)
+    int32_t resp_res = hor_res < ver_res ? hor_res : ver_res;
+    const char* size_suffix = theme_manager_get_breakpoint_suffix(resp_res);
     auto micro_tokens = theme_manager_parse_all_xml_for_suffix("ui_xml", "px", "_micro");
     auto small_tokens = theme_manager_parse_all_xml_for_suffix("ui_xml", "px", "_small");
     auto medium_tokens = theme_manager_parse_all_xml_for_suffix("ui_xml", "px", "_medium");
@@ -1150,7 +1169,7 @@ void theme_manager_refresh_layout_constants(lv_display_t* display) {
 
     // Update breakpoint subject — use shared helper so rotation never
     // downgrades XXLarge to XLarge (previous bug: missing XLARGE_MAX check).
-    UiBreakpoint bp = compute_breakpoint_from_height(ver_res);
+    UiBreakpoint bp = compute_breakpoint(resp_res);
 
     lv_subject_t* bp_subject = lv_xml_get_subject(nullptr, "ui_breakpoint");
     if (bp_subject) {
@@ -1172,17 +1191,20 @@ void theme_manager_refresh_layout_constants(lv_display_t* display) {
  * @param display The LVGL display to get resolution from
  */
 void theme_manager_register_responsive_fonts(lv_display_t* display) {
+    int32_t hor_res = lv_display_get_horizontal_resolution(display);
     int32_t ver_res = lv_display_get_vertical_resolution(display);
 
-    // Use screen height for breakpoint selection — vertical space is the constraint
-    const char* size_suffix = theme_manager_get_breakpoint_suffix(ver_res);
-    const char* size_label = (ver_res <= UI_BREAKPOINT_MICRO_MAX)    ? "MICRO"
-                             : (ver_res <= UI_BREAKPOINT_TINY_MAX)   ? "TINY"
-                             : (ver_res <= UI_BREAKPOINT_SMALL_MAX)  ? "SMALL"
-                             : (ver_res <= UI_BREAKPOINT_MEDIUM_MAX) ? "MEDIUM"
-                             : (ver_res <= UI_BREAKPOINT_LARGE_MAX)  ? "LARGE"
-                             : (ver_res <= UI_BREAKPOINT_XLARGE_MAX) ? "XLARGE"
-                                                                     : "XXLARGE";
+    // Use the smaller dimension — the cramped axis is the design constraint
+    // regardless of orientation (landscape: usually height; portrait: width).
+    int32_t resp_res = hor_res < ver_res ? hor_res : ver_res;
+    const char* size_suffix = theme_manager_get_breakpoint_suffix(resp_res);
+    const char* size_label = (resp_res <= UI_BREAKPOINT_MICRO_MAX)    ? "MICRO"
+                             : (resp_res <= UI_BREAKPOINT_TINY_MAX)   ? "TINY"
+                             : (resp_res <= UI_BREAKPOINT_SMALL_MAX)  ? "SMALL"
+                             : (resp_res <= UI_BREAKPOINT_MEDIUM_MAX) ? "MEDIUM"
+                             : (resp_res <= UI_BREAKPOINT_LARGE_MAX)  ? "LARGE"
+                             : (resp_res <= UI_BREAKPOINT_XLARGE_MAX) ? "XLARGE"
+                                                                      : "XXLARGE";
 
     lv_xml_component_scope_t* scope = lv_xml_component_get_scope("globals");
     if (!scope) {
@@ -1313,8 +1335,8 @@ void theme_manager_register_responsive_fonts(lv_display_t* display) {
         }
     }
 
-    spdlog::trace("[Theme] Responsive fonts: {} (height={}px) - auto-registered {} tokens",
-                  size_label, ver_res, registered);
+    spdlog::trace("[Theme] Responsive fonts: {} (min_dim={}px) - auto-registered {} tokens",
+                  size_label, resp_res, registered);
 }
 
 /**
@@ -1436,9 +1458,8 @@ static void theme_manager_register_theme_properties(lv_xml_component_scope_t* sc
     char buf[32];
 
     // Register border_radius and button_radius from size table + current breakpoint
-    int32_t ver_res =
-        theme_display ? lv_display_get_vertical_resolution(theme_display) : 600; // safe fallback
-    const char* suffix = theme_manager_get_breakpoint_suffix(ver_res);
+    int32_t resp_res = responsive_dimension(theme_display);
+    const char* suffix = theme_manager_get_breakpoint_suffix(resp_res);
     int radius_px = helix::BorderRadiusSizes::pixels(theme.properties.border_radius_size, suffix);
     snprintf(buf, sizeof(buf), "%d", radius_px);
     lv_xml_register_const(scope, "border_radius", buf);
@@ -1591,8 +1612,8 @@ void theme_manager_init(lv_display_t* display, bool use_dark_mode_param) {
 
     // Initialize ui_breakpoint subject for reactive responsive visibility
     {
-        int32_t ver_res_bp = lv_display_get_vertical_resolution(display);
-        UiBreakpoint bp = compute_breakpoint_from_height(ver_res_bp);
+        int32_t resp_res = responsive_dimension(display);
+        UiBreakpoint bp = compute_breakpoint(resp_res);
 
         if (!breakpoint_subject_initialized) {
             lv_subject_init_int(&ui_breakpoint_subject, to_int(bp));
@@ -1601,8 +1622,8 @@ void theme_manager_init(lv_display_t* display, bool use_dark_mode_param) {
             lv_subject_set_int(&ui_breakpoint_subject, to_int(bp));
         }
         lv_xml_register_subject(nullptr, "ui_breakpoint", &ui_breakpoint_subject);
-        spdlog::debug("[Theme] Registered ui_breakpoint subject: {} (height={})", to_int(bp),
-                      ver_res_bp);
+        spdlog::debug("[Theme] Registered ui_breakpoint subject: {} (min_dim={})", to_int(bp),
+                      resp_res);
     }
 
     // Validate critical color pairs were registered (fail-fast if missing)
@@ -1621,9 +1642,8 @@ void theme_manager_init(lv_display_t* display, bool use_dark_mode_param) {
     // Read responsive font based on current breakpoint
     // NOTE: We read the variant directly because base constants are removed to enable
     // responsive overrides (LVGL ignores lv_xml_register_const for existing constants)
-    int32_t ver_res = lv_display_get_vertical_resolution(display);
-    // Use screen height for breakpoint selection — vertical space is the constraint
-    const char* size_suffix = theme_manager_get_breakpoint_suffix(ver_res);
+    int32_t resp_res = responsive_dimension(display);
+    const char* size_suffix = theme_manager_get_breakpoint_suffix(resp_res);
 
     char font_variant_name[64];
     snprintf(font_variant_name, sizeof(font_variant_name), "font_body%s", size_suffix);
@@ -1781,7 +1801,7 @@ void theme_manager_apply_theme(const helix::ThemeData& theme, bool dark_mode) {
     // so we need update_const for subsequent changes)
     {
         const char* bp_suffix =
-            theme_manager_get_breakpoint_suffix(lv_display_get_vertical_resolution(theme_display));
+            theme_manager_get_breakpoint_suffix(responsive_dimension(theme_display));
         int radius_px =
             helix::BorderRadiusSizes::pixels(active_theme.properties.border_radius_size, bp_suffix);
         char radius_buf[16];

--- a/src/ui/ui_settings_display_sound.cpp
+++ b/src/ui/ui_settings_display_sound.cpp
@@ -950,8 +950,7 @@ void DisplaySoundSettingsOverlay::apply_preview_palette_to_screen_popups() {
 
     lv_obj_t* modal_dialog = lv_obj_find_by_name(lv_screen_active(), "modal_dialog");
     if (modal_dialog) {
-        const char* suffix =
-            theme_manager_get_breakpoint_suffix(lv_display_get_vertical_resolution(nullptr));
+        const char* suffix = theme_manager_get_breakpoint_suffix(responsive_dimension(nullptr));
         int radius_px =
             helix::BorderRadiusSizes::pixels(theme.properties.border_radius_size, suffix);
         lv_obj_set_style_radius(modal_dialog, radius_px, LV_PART_MAIN);

--- a/src/ui/ui_toast_manager.cpp
+++ b/src/ui/ui_toast_manager.cpp
@@ -244,7 +244,17 @@ void ToastManager::deinit_subjects() {
 
 void ToastManager::ensure_stack_container() {
     const int32_t margin = xml_int_const("space_2xl", 24);
-    const int32_t stack_width = compute_toast_stack_width();
+    int32_t stack_width = compute_toast_stack_width();
+
+    // The breakpoint width table is calibrated for landscape; in portrait the
+    // cramped axis is the width, so clamp to the screen or the stack overflows
+    // the left edge (it is anchored TOP_RIGHT with a margin on each side).
+    if (auto* disp = lv_display_get_default()) {
+        const int32_t max_width = lv_display_get_horizontal_resolution(disp) - 2 * margin;
+        if (max_width > 0 && stack_width > max_width) {
+            stack_width = max_width;
+        }
+    }
 
     if (!toast_stack_ || !lv_obj_is_valid(toast_stack_)) {
         lv_obj_t* layer = lv_layer_top();

--- a/tests/unit/test_theme_manager_new.cpp
+++ b/tests/unit/test_theme_manager_new.cpp
@@ -357,3 +357,76 @@ TEST_CASE_METHOD(LVGLTestFixture,
     int brightness = theme_compute_brightness(text);
     REQUIRE(brightness < 128);
 }
+
+// ============================================================================
+// responsive_dimension() — picks the smaller screen axis so portrait layouts
+// adapt to their cramped width instead of their tall height.
+// ============================================================================
+
+namespace {
+// Bufferless display: responsive_dimension() only reads the resolution, never
+// renders, so no draw buffer / flush_cb is needed.
+lv_display_t* make_test_display(int32_t w, int32_t h) {
+    return lv_display_create(w, h);
+}
+} // namespace
+
+TEST_CASE_METHOD(LVGLTestFixture, "responsive_dimension picks the smaller screen axis",
+                 "[theme][breakpoints]") {
+    SECTION("landscape — min is height (unchanged behavior)") {
+        lv_display_t* d = make_test_display(800, 480);
+        REQUIRE(responsive_dimension(d) == 480);
+        lv_display_delete(d);
+
+        d = make_test_display(1024, 600);
+        REQUIRE(responsive_dimension(d) == 600);
+        lv_display_delete(d);
+    }
+
+    SECTION("portrait — min is width (the fix)") {
+        lv_display_t* d = make_test_display(480, 800);
+        REQUIRE(responsive_dimension(d) == 480); // was 800 (ver_res) before
+        lv_display_delete(d);
+
+        d = make_test_display(320, 480);
+        REQUIRE(responsive_dimension(d) == 320);
+        lv_display_delete(d);
+
+        d = make_test_display(272, 480);
+        REQUIRE(responsive_dimension(d) == 272);
+        lv_display_delete(d);
+    }
+
+    SECTION("square — either axis") {
+        lv_display_t* d = make_test_display(480, 480);
+        REQUIRE(responsive_dimension(d) == 480);
+        lv_display_delete(d);
+    }
+
+    SECTION("null display falls back to the default display") {
+        // lv_display_get_default() returns the first display created — here the
+        // fixture's TEST_DISPLAY_WIDTH x TEST_DISPLAY_HEIGHT screen — so the
+        // fallback resolves to its smaller axis, not any later-created display.
+        REQUIRE(responsive_dimension(nullptr) == std::min(TEST_DISPLAY_WIDTH, TEST_DISPLAY_HEIGHT));
+    }
+}
+
+TEST_CASE_METHOD(LVGLTestFixture,
+                 "responsive_dimension feeds breakpoint selection — portrait no longer overflows",
+                 "[theme][breakpoints]") {
+    // End-to-end: a 480x800 portrait screen used to resolve to _xlarge (via
+    // ver_res=800) and overflow; it now resolves to _medium via the 480 width.
+    lv_display_t* d = make_test_display(480, 800);
+    REQUIRE(std::string(theme_manager_get_breakpoint_suffix(responsive_dimension(d))) == "_medium");
+    lv_display_delete(d);
+
+    // 320x480 portrait resolves to _tiny instead of _medium.
+    d = make_test_display(320, 480);
+    REQUIRE(std::string(theme_manager_get_breakpoint_suffix(responsive_dimension(d))) == "_tiny");
+    lv_display_delete(d);
+
+    // Landscape 800x480 is byte-identical to the old behavior — still _medium.
+    d = make_test_display(800, 480);
+    REQUIRE(std::string(theme_manager_get_breakpoint_suffix(responsive_dimension(d))) == "_medium");
+    lv_display_delete(d);
+}

--- a/ui_xml/micro_portrait/app_layout.xml
+++ b/ui_xml/micro_portrait/app_layout.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2025-2026 356C LLC -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<component>
+  <!-- Portrait variant: vertical container with content area on top + nav bar on bottom -->
+  <view extends="lv_obj"
+        width="100%" height="100%" style_bg_opa="0%" style_border_width="0" style_pad_all="0" flex_flow="column">
+    <!-- Content area (top, grows to fill space above navbar) -->
+    <lv_obj name="content_area" width="100%" flex_grow="1" style_bg_opa="0%" style_pad_all="0" flex_flow="column">
+      <!-- Panel container (grows to fill remaining space) -->
+      <!-- All panels are stacked here, navigation controls visibility -->
+      <lv_obj name="panel_container" width="100%" flex_grow="1" style_bg_opa="0%" style_pad_all="0">
+        <!-- Panel 0: Home (visible by default) -->
+        <home_panel name="home_panel"/>
+        <!-- Panel 1: Print Select (hidden by default) -->
+        <print_select_panel name="print_select_panel"/>
+        <!-- Panel 2: Controls (hidden by default) -->
+        <controls_panel name="controls_panel"/>
+        <!-- Panel 3: Filament (hidden by default) -->
+        <filament_panel name="filament_panel"/>
+        <!-- Panel 4: Settings (hidden by default) -->
+        <settings_panel name="settings_panel"/>
+        <!-- Panel 5: Advanced (hidden by default) -->
+        <advanced_panel name="advanced_panel"/>
+      </lv_obj>
+    </lv_obj>
+    <!-- Navigation bar (bottom) -->
+    <navigation_bar name="navbar"/>
+  </view>
+</component>

--- a/ui_xml/micro_portrait/navigation_bar.xml
+++ b/ui_xml/micro_portrait/navigation_bar.xml
@@ -2,31 +2,22 @@
 <!-- Copyright (C) 2025-2026 356C LLC -->
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <component>
-  <consts>
-    <!-- Nav bar width per breakpoint (selected by horizontal resolution in C++) -->
-    <px name="nav_width_micro" value="42"/>
-    <px name="nav_width_tiny" value="54"/>
-    <px name="nav_width_small" value="76"/>
-    <px name="nav_width_medium" value="104"/>
-    <px name="nav_width_large" value="132"/>
-    <!-- Nav bar height per breakpoint (used by portrait variant; auto-selected by vertical resolution) -->
-    <px name="nav_height_micro" value="42"/>
-    <px name="nav_height_tiny" value="48"/>
-    <px name="nav_height_small" value="56"/>
-    <px name="nav_height_medium" value="64"/>
-    <px name="nav_height_large" value="76"/>
-    <px name="nav_height_xlarge" value="88"/>
-  </consts>
+  <!-- Portrait variant: horizontal bottom navigation bar.
+       Buttons share the row equally via flex_grow.
+       nav_height token is defined in ui_xml/navigation_bar.xml consts. -->
   <view extends="lv_obj"
-        width="#nav_width" height="100%" style_pad_top="#space_xl" style_pad_bottom="#space_xl" style_pad_left="0" style_pad_right="0" flex_flow="column"
-        style_flex_main_place="start" style_flex_track_place="center" style_flex_cross_place="center"
-        style_border_width="0" style_radius="0" scrollable="false" style_bg_color="#card_bg" style_bg_opa="255">
+        width="100%" height="#nav_height"
+        style_pad_left="#space_xl" style_pad_right="#space_xl" style_pad_top="0" style_pad_bottom="0"
+        flex_flow="row"
+        style_flex_main_place="center" style_flex_track_place="center" style_flex_cross_place="center"
+        style_border_width="0" style_radius="0" scrollable="false"
+        style_bg_color="#card_bg" style_bg_opa="255">
     <!-- ================================================================== -->
-    <!-- Edit Mode Buttons - visible only during home panel grid edit      -->
+    <!-- Edit Mode Buttons - visible only during home panel grid edit       -->
     <!-- ================================================================== -->
     <!-- Add Widget (+) button -->
     <ui_button name="nav_btn_edit_add"
-               width="100%" style_min_height="48" variant="ghost" flex_flow="column"
+               height="100%" style_min_width="48" variant="ghost" flex_flow="column"
                style_flex_main_place="center" style_flex_cross_place="center"
                style_flex_track_place="center" style_border_width="0" hidden="true">
       <bind_flag_if_eq subject="home_edit_mode" flag="hidden" ref_value="0"/>
@@ -35,7 +26,7 @@
     </ui_button>
     <!-- Done button (exits edit mode) — filled primary style -->
     <ui_button name="nav_btn_edit_done"
-               width="90%" style_min_height="36" variant="primary"
+               height="90%" style_min_width="36" variant="primary"
                text="Done" translation_tag="Done" hidden="true">
       <bind_flag_if_eq subject="home_edit_mode" flag="hidden" ref_value="0"/>
       <event_cb trigger="clicked" callback="on_edit_done_clicked"/>
@@ -45,7 +36,7 @@
     <!-- ================================================================== -->
     <!-- Home Button (Panel 0) -->
     <ui_button name="nav_btn_home"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0">
       <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
@@ -59,62 +50,47 @@
       </icon>
     </ui_button>
     <!-- Controls Button (Panel 2) - CONNECTION + KLIPPY READY REQUIRED -->
-    <!-- Uses combined nav_buttons_enabled subject (1=enabled when connected AND klippy ready) -->
     <ui_button name="nav_btn_controls"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0">
-      <!-- Disabled clickability when not enabled (disconnected OR klippy not ready) -->
       <bind_state_if_not_eq subject="nav_buttons_enabled" state="disabled" ref_value="1"/>
-      <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
-      <!-- Normal icons container - visible only when enabled -->
       <lv_obj name="nav_controls_icons" clickable="false" style_pad_all="0">
         <bind_flag_if_eq subject="nav_buttons_enabled" flag="hidden" ref_value="0"/>
-        <!-- Active icon (accent) - shown when on controls panel -->
         <icon name="nav_icon_controls_active" src="fine_tune" size="#icon_size" variant="primary" hidden="true">
           <bind_flag_if_not_eq subject="active_panel" flag="hidden" ref_value="2"/>
         </icon>
-        <!-- Inactive icon (secondary) - shown when not on controls panel -->
         <icon name="nav_icon_controls_inactive" src="fine_tune" size="#icon_size" variant="secondary">
           <bind_flag_if_eq subject="active_panel" flag="hidden" ref_value="2"/>
         </icon>
       </lv_obj>
-      <!-- Disabled icon - visible only when disabled (disconnected OR klippy not ready) -->
       <icon name="nav_icon_controls_disabled" src="fine_tune" size="#icon_size" variant="disabled">
         <bind_flag_if_eq subject="nav_buttons_enabled" flag="hidden" ref_value="1"/>
       </icon>
     </ui_button>
     <!-- Filament Button (Panel 3) - CONNECTION + KLIPPY READY REQUIRED -->
-    <!-- Uses combined nav_buttons_enabled subject (1=enabled when connected AND klippy ready) -->
     <ui_button name="nav_btn_filament"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0">
-      <!-- Disabled clickability when not enabled (disconnected OR klippy not ready) -->
       <bind_state_if_not_eq subject="nav_buttons_enabled" state="disabled" ref_value="1"/>
-      <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
-      <!-- Normal icons container - visible only when enabled -->
       <lv_obj name="nav_filament_icons" clickable="false" style_pad_all="0">
         <bind_flag_if_eq subject="nav_buttons_enabled" flag="hidden" ref_value="0"/>
-        <!-- Active icon (accent) - shown when on filament panel -->
         <icon name="nav_icon_filament_active" src="filament" size="#icon_size" variant="primary" hidden="true">
           <bind_flag_if_not_eq subject="active_panel" flag="hidden" ref_value="3"/>
         </icon>
-        <!-- Inactive icon (secondary) - shown when not on filament panel -->
         <icon name="nav_icon_filament_inactive" src="filament" size="#icon_size" variant="secondary">
           <bind_flag_if_eq subject="active_panel" flag="hidden" ref_value="3"/>
         </icon>
       </lv_obj>
-      <!-- Disabled icon - visible only when disabled (disconnected OR klippy not ready) -->
       <icon name="nav_icon_filament_disabled" src="filament" size="#icon_size" variant="disabled">
         <bind_flag_if_eq subject="nav_buttons_enabled" flag="hidden" ref_value="1"/>
       </icon>
     </ui_button>
     <!-- Settings Button (Panel 4) -->
     <ui_button name="nav_btn_settings"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0">
-      <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
       <icon name="nav_icon_settings_active" src="settings" size="#icon_size" variant="primary" hidden="true">
         <bind_flag_if_not_eq subject="active_panel" flag="hidden" ref_value="4"/>
@@ -125,9 +101,8 @@
     </ui_button>
     <!-- Advanced Button (Panel 5) -->
     <ui_button name="nav_btn_advanced"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0">
-      <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
       <icon name="nav_icon_advanced_active" src="dots_vertical" size="#icon_size" variant="primary" hidden="true">
         <bind_flag_if_not_eq subject="active_panel" flag="hidden" ref_value="5"/>
@@ -138,11 +113,10 @@
     </ui_button>
     <!-- Printer switcher button — visible only when setting enabled -->
     <ui_button name="nav_printer_badge"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0"
                hidden="true">
       <bind_flag_if_eq subject="show_printer_switcher" flag="hidden" ref_value="0"/>
-      <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
       <lv_obj name="nav_printer_icon_wrap" clickable="false" event_bubble="true"
               style_pad_all="0" style_border_width="0" style_bg_opa="0">

--- a/ui_xml/portrait/app_layout.xml
+++ b/ui_xml/portrait/app_layout.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2025-2026 356C LLC -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<component>
+  <!-- Portrait variant: vertical container with content area on top + nav bar on bottom -->
+  <view extends="lv_obj"
+        width="100%" height="100%" style_bg_opa="0%" style_border_width="0" style_pad_all="0" flex_flow="column">
+    <!-- Content area (top, grows to fill space above navbar) -->
+    <lv_obj name="content_area" width="100%" flex_grow="1" style_bg_opa="0%" style_pad_all="0" flex_flow="column">
+      <!-- Panel container (grows to fill remaining space) -->
+      <!-- All panels are stacked here, navigation controls visibility -->
+      <lv_obj name="panel_container" width="100%" flex_grow="1" style_bg_opa="0%" style_pad_all="0">
+        <!-- Panel 0: Home (visible by default) -->
+        <home_panel name="home_panel"/>
+        <!-- Panel 1: Print Select (hidden by default) -->
+        <print_select_panel name="print_select_panel"/>
+        <!-- Panel 2: Controls (hidden by default) -->
+        <controls_panel name="controls_panel"/>
+        <!-- Panel 3: Filament (hidden by default) -->
+        <filament_panel name="filament_panel"/>
+        <!-- Panel 4: Settings (hidden by default) -->
+        <settings_panel name="settings_panel"/>
+        <!-- Panel 5: Advanced (hidden by default) -->
+        <advanced_panel name="advanced_panel"/>
+      </lv_obj>
+    </lv_obj>
+    <!-- Navigation bar (bottom) -->
+    <navigation_bar name="navbar"/>
+  </view>
+</component>

--- a/ui_xml/portrait/navigation_bar.xml
+++ b/ui_xml/portrait/navigation_bar.xml
@@ -2,31 +2,22 @@
 <!-- Copyright (C) 2025-2026 356C LLC -->
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <component>
-  <consts>
-    <!-- Nav bar width per breakpoint (selected by horizontal resolution in C++) -->
-    <px name="nav_width_micro" value="42"/>
-    <px name="nav_width_tiny" value="54"/>
-    <px name="nav_width_small" value="76"/>
-    <px name="nav_width_medium" value="104"/>
-    <px name="nav_width_large" value="132"/>
-    <!-- Nav bar height per breakpoint (used by portrait variant; auto-selected by vertical resolution) -->
-    <px name="nav_height_micro" value="42"/>
-    <px name="nav_height_tiny" value="48"/>
-    <px name="nav_height_small" value="56"/>
-    <px name="nav_height_medium" value="64"/>
-    <px name="nav_height_large" value="76"/>
-    <px name="nav_height_xlarge" value="88"/>
-  </consts>
+  <!-- Portrait variant: horizontal bottom navigation bar.
+       Buttons share the row equally via flex_grow.
+       nav_height token is defined in ui_xml/navigation_bar.xml consts. -->
   <view extends="lv_obj"
-        width="#nav_width" height="100%" style_pad_top="#space_xl" style_pad_bottom="#space_xl" style_pad_left="0" style_pad_right="0" flex_flow="column"
-        style_flex_main_place="start" style_flex_track_place="center" style_flex_cross_place="center"
-        style_border_width="0" style_radius="0" scrollable="false" style_bg_color="#card_bg" style_bg_opa="255">
+        width="100%" height="#nav_height"
+        style_pad_left="#space_xl" style_pad_right="#space_xl" style_pad_top="0" style_pad_bottom="0"
+        flex_flow="row"
+        style_flex_main_place="center" style_flex_track_place="center" style_flex_cross_place="center"
+        style_border_width="0" style_radius="0" scrollable="false"
+        style_bg_color="#card_bg" style_bg_opa="255">
     <!-- ================================================================== -->
-    <!-- Edit Mode Buttons - visible only during home panel grid edit      -->
+    <!-- Edit Mode Buttons - visible only during home panel grid edit       -->
     <!-- ================================================================== -->
     <!-- Add Widget (+) button -->
     <ui_button name="nav_btn_edit_add"
-               width="100%" style_min_height="48" variant="ghost" flex_flow="column"
+               height="100%" style_min_width="48" variant="ghost" flex_flow="column"
                style_flex_main_place="center" style_flex_cross_place="center"
                style_flex_track_place="center" style_border_width="0" hidden="true">
       <bind_flag_if_eq subject="home_edit_mode" flag="hidden" ref_value="0"/>
@@ -35,7 +26,7 @@
     </ui_button>
     <!-- Done button (exits edit mode) — filled primary style -->
     <ui_button name="nav_btn_edit_done"
-               width="90%" style_min_height="36" variant="primary"
+               height="90%" style_min_width="36" variant="primary"
                text="Done" translation_tag="Done" hidden="true">
       <bind_flag_if_eq subject="home_edit_mode" flag="hidden" ref_value="0"/>
       <event_cb trigger="clicked" callback="on_edit_done_clicked"/>
@@ -45,7 +36,7 @@
     <!-- ================================================================== -->
     <!-- Home Button (Panel 0) -->
     <ui_button name="nav_btn_home"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0">
       <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
@@ -59,62 +50,47 @@
       </icon>
     </ui_button>
     <!-- Controls Button (Panel 2) - CONNECTION + KLIPPY READY REQUIRED -->
-    <!-- Uses combined nav_buttons_enabled subject (1=enabled when connected AND klippy ready) -->
     <ui_button name="nav_btn_controls"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0">
-      <!-- Disabled clickability when not enabled (disconnected OR klippy not ready) -->
       <bind_state_if_not_eq subject="nav_buttons_enabled" state="disabled" ref_value="1"/>
-      <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
-      <!-- Normal icons container - visible only when enabled -->
       <lv_obj name="nav_controls_icons" clickable="false" style_pad_all="0">
         <bind_flag_if_eq subject="nav_buttons_enabled" flag="hidden" ref_value="0"/>
-        <!-- Active icon (accent) - shown when on controls panel -->
         <icon name="nav_icon_controls_active" src="fine_tune" size="#icon_size" variant="primary" hidden="true">
           <bind_flag_if_not_eq subject="active_panel" flag="hidden" ref_value="2"/>
         </icon>
-        <!-- Inactive icon (secondary) - shown when not on controls panel -->
         <icon name="nav_icon_controls_inactive" src="fine_tune" size="#icon_size" variant="secondary">
           <bind_flag_if_eq subject="active_panel" flag="hidden" ref_value="2"/>
         </icon>
       </lv_obj>
-      <!-- Disabled icon - visible only when disabled (disconnected OR klippy not ready) -->
       <icon name="nav_icon_controls_disabled" src="fine_tune" size="#icon_size" variant="disabled">
         <bind_flag_if_eq subject="nav_buttons_enabled" flag="hidden" ref_value="1"/>
       </icon>
     </ui_button>
     <!-- Filament Button (Panel 3) - CONNECTION + KLIPPY READY REQUIRED -->
-    <!-- Uses combined nav_buttons_enabled subject (1=enabled when connected AND klippy ready) -->
     <ui_button name="nav_btn_filament"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0">
-      <!-- Disabled clickability when not enabled (disconnected OR klippy not ready) -->
       <bind_state_if_not_eq subject="nav_buttons_enabled" state="disabled" ref_value="1"/>
-      <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
-      <!-- Normal icons container - visible only when enabled -->
       <lv_obj name="nav_filament_icons" clickable="false" style_pad_all="0">
         <bind_flag_if_eq subject="nav_buttons_enabled" flag="hidden" ref_value="0"/>
-        <!-- Active icon (accent) - shown when on filament panel -->
         <icon name="nav_icon_filament_active" src="filament" size="#icon_size" variant="primary" hidden="true">
           <bind_flag_if_not_eq subject="active_panel" flag="hidden" ref_value="3"/>
         </icon>
-        <!-- Inactive icon (secondary) - shown when not on filament panel -->
         <icon name="nav_icon_filament_inactive" src="filament" size="#icon_size" variant="secondary">
           <bind_flag_if_eq subject="active_panel" flag="hidden" ref_value="3"/>
         </icon>
       </lv_obj>
-      <!-- Disabled icon - visible only when disabled (disconnected OR klippy not ready) -->
       <icon name="nav_icon_filament_disabled" src="filament" size="#icon_size" variant="disabled">
         <bind_flag_if_eq subject="nav_buttons_enabled" flag="hidden" ref_value="1"/>
       </icon>
     </ui_button>
     <!-- Settings Button (Panel 4) -->
     <ui_button name="nav_btn_settings"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0">
-      <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
       <icon name="nav_icon_settings_active" src="settings" size="#icon_size" variant="primary" hidden="true">
         <bind_flag_if_not_eq subject="active_panel" flag="hidden" ref_value="4"/>
@@ -125,9 +101,8 @@
     </ui_button>
     <!-- Advanced Button (Panel 5) -->
     <ui_button name="nav_btn_advanced"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0">
-      <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
       <icon name="nav_icon_advanced_active" src="dots_vertical" size="#icon_size" variant="primary" hidden="true">
         <bind_flag_if_not_eq subject="active_panel" flag="hidden" ref_value="5"/>
@@ -138,11 +113,10 @@
     </ui_button>
     <!-- Printer switcher button — visible only when setting enabled -->
     <ui_button name="nav_printer_badge"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0"
                hidden="true">
       <bind_flag_if_eq subject="show_printer_switcher" flag="hidden" ref_value="0"/>
-      <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
       <lv_obj name="nav_printer_icon_wrap" clickable="false" event_bubble="true"
               style_pad_all="0" style_border_width="0" style_bg_opa="0">

--- a/ui_xml/tiny_portrait/app_layout.xml
+++ b/ui_xml/tiny_portrait/app_layout.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2025-2026 356C LLC -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<component>
+  <!-- Portrait variant: vertical container with content area on top + nav bar on bottom -->
+  <view extends="lv_obj"
+        width="100%" height="100%" style_bg_opa="0%" style_border_width="0" style_pad_all="0" flex_flow="column">
+    <!-- Content area (top, grows to fill space above navbar) -->
+    <lv_obj name="content_area" width="100%" flex_grow="1" style_bg_opa="0%" style_pad_all="0" flex_flow="column">
+      <!-- Panel container (grows to fill remaining space) -->
+      <!-- All panels are stacked here, navigation controls visibility -->
+      <lv_obj name="panel_container" width="100%" flex_grow="1" style_bg_opa="0%" style_pad_all="0">
+        <!-- Panel 0: Home (visible by default) -->
+        <home_panel name="home_panel"/>
+        <!-- Panel 1: Print Select (hidden by default) -->
+        <print_select_panel name="print_select_panel"/>
+        <!-- Panel 2: Controls (hidden by default) -->
+        <controls_panel name="controls_panel"/>
+        <!-- Panel 3: Filament (hidden by default) -->
+        <filament_panel name="filament_panel"/>
+        <!-- Panel 4: Settings (hidden by default) -->
+        <settings_panel name="settings_panel"/>
+        <!-- Panel 5: Advanced (hidden by default) -->
+        <advanced_panel name="advanced_panel"/>
+      </lv_obj>
+    </lv_obj>
+    <!-- Navigation bar (bottom) -->
+    <navigation_bar name="navbar"/>
+  </view>
+</component>

--- a/ui_xml/tiny_portrait/navigation_bar.xml
+++ b/ui_xml/tiny_portrait/navigation_bar.xml
@@ -2,31 +2,22 @@
 <!-- Copyright (C) 2025-2026 356C LLC -->
 <!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <component>
-  <consts>
-    <!-- Nav bar width per breakpoint (selected by horizontal resolution in C++) -->
-    <px name="nav_width_micro" value="42"/>
-    <px name="nav_width_tiny" value="54"/>
-    <px name="nav_width_small" value="76"/>
-    <px name="nav_width_medium" value="104"/>
-    <px name="nav_width_large" value="132"/>
-    <!-- Nav bar height per breakpoint (used by portrait variant; auto-selected by vertical resolution) -->
-    <px name="nav_height_micro" value="42"/>
-    <px name="nav_height_tiny" value="48"/>
-    <px name="nav_height_small" value="56"/>
-    <px name="nav_height_medium" value="64"/>
-    <px name="nav_height_large" value="76"/>
-    <px name="nav_height_xlarge" value="88"/>
-  </consts>
+  <!-- Portrait variant: horizontal bottom navigation bar.
+       Buttons share the row equally via flex_grow.
+       nav_height token is defined in ui_xml/navigation_bar.xml consts. -->
   <view extends="lv_obj"
-        width="#nav_width" height="100%" style_pad_top="#space_xl" style_pad_bottom="#space_xl" style_pad_left="0" style_pad_right="0" flex_flow="column"
-        style_flex_main_place="start" style_flex_track_place="center" style_flex_cross_place="center"
-        style_border_width="0" style_radius="0" scrollable="false" style_bg_color="#card_bg" style_bg_opa="255">
+        width="100%" height="#nav_height"
+        style_pad_left="#space_xl" style_pad_right="#space_xl" style_pad_top="0" style_pad_bottom="0"
+        flex_flow="row"
+        style_flex_main_place="center" style_flex_track_place="center" style_flex_cross_place="center"
+        style_border_width="0" style_radius="0" scrollable="false"
+        style_bg_color="#card_bg" style_bg_opa="255">
     <!-- ================================================================== -->
-    <!-- Edit Mode Buttons - visible only during home panel grid edit      -->
+    <!-- Edit Mode Buttons - visible only during home panel grid edit       -->
     <!-- ================================================================== -->
     <!-- Add Widget (+) button -->
     <ui_button name="nav_btn_edit_add"
-               width="100%" style_min_height="48" variant="ghost" flex_flow="column"
+               height="100%" style_min_width="48" variant="ghost" flex_flow="column"
                style_flex_main_place="center" style_flex_cross_place="center"
                style_flex_track_place="center" style_border_width="0" hidden="true">
       <bind_flag_if_eq subject="home_edit_mode" flag="hidden" ref_value="0"/>
@@ -35,7 +26,7 @@
     </ui_button>
     <!-- Done button (exits edit mode) — filled primary style -->
     <ui_button name="nav_btn_edit_done"
-               width="90%" style_min_height="36" variant="primary"
+               height="90%" style_min_width="36" variant="primary"
                text="Done" translation_tag="Done" hidden="true">
       <bind_flag_if_eq subject="home_edit_mode" flag="hidden" ref_value="0"/>
       <event_cb trigger="clicked" callback="on_edit_done_clicked"/>
@@ -45,7 +36,7 @@
     <!-- ================================================================== -->
     <!-- Home Button (Panel 0) -->
     <ui_button name="nav_btn_home"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0">
       <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
@@ -59,62 +50,47 @@
       </icon>
     </ui_button>
     <!-- Controls Button (Panel 2) - CONNECTION + KLIPPY READY REQUIRED -->
-    <!-- Uses combined nav_buttons_enabled subject (1=enabled when connected AND klippy ready) -->
     <ui_button name="nav_btn_controls"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0">
-      <!-- Disabled clickability when not enabled (disconnected OR klippy not ready) -->
       <bind_state_if_not_eq subject="nav_buttons_enabled" state="disabled" ref_value="1"/>
-      <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
-      <!-- Normal icons container - visible only when enabled -->
       <lv_obj name="nav_controls_icons" clickable="false" style_pad_all="0">
         <bind_flag_if_eq subject="nav_buttons_enabled" flag="hidden" ref_value="0"/>
-        <!-- Active icon (accent) - shown when on controls panel -->
         <icon name="nav_icon_controls_active" src="fine_tune" size="#icon_size" variant="primary" hidden="true">
           <bind_flag_if_not_eq subject="active_panel" flag="hidden" ref_value="2"/>
         </icon>
-        <!-- Inactive icon (secondary) - shown when not on controls panel -->
         <icon name="nav_icon_controls_inactive" src="fine_tune" size="#icon_size" variant="secondary">
           <bind_flag_if_eq subject="active_panel" flag="hidden" ref_value="2"/>
         </icon>
       </lv_obj>
-      <!-- Disabled icon - visible only when disabled (disconnected OR klippy not ready) -->
       <icon name="nav_icon_controls_disabled" src="fine_tune" size="#icon_size" variant="disabled">
         <bind_flag_if_eq subject="nav_buttons_enabled" flag="hidden" ref_value="1"/>
       </icon>
     </ui_button>
     <!-- Filament Button (Panel 3) - CONNECTION + KLIPPY READY REQUIRED -->
-    <!-- Uses combined nav_buttons_enabled subject (1=enabled when connected AND klippy ready) -->
     <ui_button name="nav_btn_filament"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0">
-      <!-- Disabled clickability when not enabled (disconnected OR klippy not ready) -->
       <bind_state_if_not_eq subject="nav_buttons_enabled" state="disabled" ref_value="1"/>
-      <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
-      <!-- Normal icons container - visible only when enabled -->
       <lv_obj name="nav_filament_icons" clickable="false" style_pad_all="0">
         <bind_flag_if_eq subject="nav_buttons_enabled" flag="hidden" ref_value="0"/>
-        <!-- Active icon (accent) - shown when on filament panel -->
         <icon name="nav_icon_filament_active" src="filament" size="#icon_size" variant="primary" hidden="true">
           <bind_flag_if_not_eq subject="active_panel" flag="hidden" ref_value="3"/>
         </icon>
-        <!-- Inactive icon (secondary) - shown when not on filament panel -->
         <icon name="nav_icon_filament_inactive" src="filament" size="#icon_size" variant="secondary">
           <bind_flag_if_eq subject="active_panel" flag="hidden" ref_value="3"/>
         </icon>
       </lv_obj>
-      <!-- Disabled icon - visible only when disabled (disconnected OR klippy not ready) -->
       <icon name="nav_icon_filament_disabled" src="filament" size="#icon_size" variant="disabled">
         <bind_flag_if_eq subject="nav_buttons_enabled" flag="hidden" ref_value="1"/>
       </icon>
     </ui_button>
     <!-- Settings Button (Panel 4) -->
     <ui_button name="nav_btn_settings"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0">
-      <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
       <icon name="nav_icon_settings_active" src="settings" size="#icon_size" variant="primary" hidden="true">
         <bind_flag_if_not_eq subject="active_panel" flag="hidden" ref_value="4"/>
@@ -125,9 +101,8 @@
     </ui_button>
     <!-- Advanced Button (Panel 5) -->
     <ui_button name="nav_btn_advanced"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0">
-      <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
       <icon name="nav_icon_advanced_active" src="dots_vertical" size="#icon_size" variant="primary" hidden="true">
         <bind_flag_if_not_eq subject="active_panel" flag="hidden" ref_value="5"/>
@@ -138,11 +113,10 @@
     </ui_button>
     <!-- Printer switcher button — visible only when setting enabled -->
     <ui_button name="nav_printer_badge"
-               width="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
+               height="100%" flex_grow="1" variant="ghost" flex_flow="column" style_flex_main_place="center"
                style_flex_cross_place="center" style_flex_track_place="center" style_border_width="0"
                hidden="true">
       <bind_flag_if_eq subject="show_printer_switcher" flag="hidden" ref_value="0"/>
-      <!-- Disabled during grid edit mode -->
       <bind_state_if_eq subject="home_edit_mode" state="disabled" ref_value="1"/>
       <lv_obj name="nav_printer_icon_wrap" clickable="false" event_bubble="true"
               style_pad_all="0" style_border_width="0" style_bg_opa="0">


### PR DESCRIPTION
## Why

HelixScreen auto-detects a narrow panel (aspect ratio < 0.8 — e.g. the Waveshare 11.9" DSI at 320×1480) as the `portrait` layout, but the project ships **no portrait XML**, so it silently falls back to the 800×480 landscape UI cropped into a narrow column. On top of that, the responsive system picked its breakpoint from **vertical resolution only**, so a portrait screen sized every element for its *long* axis and overflowed its *short* one — the UI looked oversized and clipped at the edges.

This PR lays the **foundation** for portrait: correct breakpoint selection, a bottom-navbar app shell for the three portrait classes, and an overflow fix for toasts. It is intentionally scoped to structure — per-panel content reflow is a follow-up (see *Scope* below).

## What changed

**1. Breakpoint selection uses the constrained axis (`min(width, height)`)**
- Added `responsive_dimension(display) = min(hor, ver)` and switched the breakpoint callsites in `theme_manager.cpp` from `ver_res` to this min-dimension. Renamed `compute_breakpoint_from_height` → `compute_breakpoint`.
- Landscape is **behaviorally identical** (its cramped axis was already height). Portrait now picks a breakpoint sized to its actual narrow axis:

  | Resolution | Before | After | Effect |
  |---|---|---|---|
  | 800×480 landscape | MEDIUM | MEDIUM | unchanged |
  | 1024×600 landscape | LARGE | LARGE | unchanged |
  | 480×272 landscape | MICRO | MICRO | unchanged |
  | 480×800 portrait | XLARGE | MEDIUM | fixes overflow |
  | 320×480 portrait | MEDIUM | TINY | fixes overflow |
  | 272×480 portrait | MEDIUM | MICRO | fixes overflow |

- Covered by new unit tests in `test_theme_manager_new.cpp` (min-axis selection in both orientations, null-display fallback, end-to-end suffix).

**2. Portrait app shell (bottom navbar)**
- Added `nav_height_*` tokens to `ui_xml/navigation_bar.xml` (micro 42 / tiny 48 / small 56 / medium 64 / large 76 / xlarge 88), mirroring the existing `nav_width_*` ladder.
- New `app_layout.xml` (flex column, content on top / navbar on bottom) and `navigation_bar.xml` (full-width horizontal bar) for all three portrait classes: `portrait/`, `tiny_portrait/`, `micro_portrait/`.

**3. Toast overflow fix**
- The toast stack width table is calibrated for landscape; in portrait the cramped axis is the width, so a fixed-width stack anchored top-right spilled off the left edge on narrow screens. Clamped stack width to `min(table_width, screen_width − 2·margin)`. Only screens narrower than ~448px are affected; wider screens are unchanged.

## Testing
- Clean build against current `main`.
- Theme/breakpoints/layout/grid/toast suites green (4100 assertions / 159 cases).
- Emulator-verified: 480×800, 320×480, 272×480 portrait render correctly with the bottom navbar; **800×480 landscape unchanged, no regression.**

## Scope / follow-ups (not in this PR)
The foundation is in place; **individual panel content and overlays still use landscape/hardcoded pixel widths** and will overflow on narrow portrait screens. Deferred to a per-panel sweep: the structural two-column panels (`print_status`, `print_select`, `ams`, `print_tune`, `controls`), home dashboard cards, and a general fluid-sizing pass (px → `%` / `flex_grow` / min-max). Opened as a **draft** to signal that this is the base layer, not the full portrait treatment.