### PR TITLE
fix(ui): make temperature tool selector touch-friendly on Snapmaker U1

### DIFF
--- a/src/ui/ui_overlay_temp_graph.cpp
+++ b/src/ui/ui_overlay_temp_graph.cpp
@@ -778,11 +778,25 @@ void TempGraphOverlay::rebuild_extruder_selector() {
     std::sort(sorted.begin(), sorted.end(),
               [](const auto* a, const auto* b) { return a->name < b->name; });
 
+    // Touch-friendly pill sizing (esp. Tiny breakpoint / 480x320): the four tool
+    // pills share the narrow 33% control column. Grow each pill to fill the row
+    // equally and give it a real minimum touch height plus a body-size digit,
+    // instead of shrinking to the glyph (was font_small + content-size, ~18px
+    // tall and near-untappable). Mirrors tool_switcher_widget's pill sizing.
+    const int32_t pill_min_h = theme_manager_get_spacing("button_height_sm");
+    const int32_t pill_pad_ver = theme_manager_get_spacing("space_xxs");
+    const int32_t pill_pad_hor = theme_manager_get_spacing("space_xs");
+
     for (const auto* ext : sorted) {
         lv_obj_t* btn = lv_obj_create(extruder_selector_row_);
-        lv_obj_set_size(btn, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
-        lv_obj_set_style_pad_all(btn, theme_manager_get_spacing("space_xs"), 0);
-        lv_obj_set_style_radius(btn, theme_manager_get_spacing("space_xs"), 0);
+        lv_obj_set_height(btn, LV_SIZE_CONTENT);
+        lv_obj_set_flex_grow(btn, 1); // share the column width equally across pills
+        lv_obj_set_style_min_height(btn, pill_min_h, 0);
+        lv_obj_set_style_pad_ver(btn, pill_pad_ver, 0);
+        lv_obj_set_style_pad_hor(btn, pill_pad_hor, 0);
+        // Match the rounded-rectangle radius of the rest of the UI (preset
+        // buttons, dropdowns) rather than a full-circle pill.
+        lv_obj_set_style_radius(btn, ThemeManager::instance().current_palette().border_radius, 0);
         lv_obj_set_style_bg_opa(btn, LV_OPA_COVER, 0);
         lv_obj_remove_flag(btn, LV_OBJ_FLAG_SCROLLABLE);
         lv_obj_add_flag(btn, LV_OBJ_FLAG_CLICKABLE);
@@ -791,6 +805,12 @@ void TempGraphOverlay::rebuild_extruder_selector() {
         lv_obj_set_style_bg_color(
             btn,
             is_active ? theme_manager_get_color("primary") : theme_manager_get_color("card_bg"), 0);
+        // Inactive pills get an outline like the "Off" ghost button; the active
+        // pill stays a solid primary fill with no border.
+        lv_obj_set_style_border_width(
+            btn, is_active ? 0 : ThemeManager::instance().current_palette().border_width, 0);
+        lv_obj_set_style_border_color(btn, theme_manager_get_color("border"), 0);
+        lv_obj_set_style_border_opa(btn, LV_OPA_COVER, 0);
 
         lv_obj_t* label = lv_label_create(btn);
         // Compact pill label: show only the trailing number from "Nozzle N".
@@ -802,12 +822,13 @@ void TempGraphOverlay::rebuild_extruder_selector() {
                                     ? ext->display_name.substr(space_pos + 1)
                                     : ext->display_name;
         lv_label_set_text(label, pill_text.c_str());
-        lv_obj_set_style_text_font(label, theme_manager_get_font("font_small"), 0);
+        lv_obj_set_style_text_font(label, theme_manager_get_font("font_body"), 0);
         lv_obj_set_style_text_color(
             label,
             is_active ? theme_manager_get_color("on_primary") : theme_manager_get_color("text"), 0);
         lv_obj_remove_flag(label, LV_OBJ_FLAG_CLICKABLE);
         lv_obj_add_flag(label, LV_OBJ_FLAG_EVENT_BUBBLE);
+        lv_obj_center(label); // center the digit within the grown pill
 
         // Store name as obj name for lookup in callback
         lv_obj_set_name(btn, ext->name.c_str());

--- a/src/ui/ui_overlay_temp_graph.cpp
+++ b/src/ui/ui_overlay_temp_graph.cpp
@@ -786,6 +786,11 @@ void TempGraphOverlay::rebuild_extruder_selector() {
     const int32_t pill_min_h = theme_manager_get_spacing("button_height_sm");
     const int32_t pill_pad_ver = theme_manager_get_spacing("space_xxs");
     const int32_t pill_pad_hor = theme_manager_get_spacing("space_xs");
+    // Rounded-rectangle radius + outline width, matching the preset buttons and
+    // dropdowns (both are breakpoint-aware theme consts, same values used in XML
+    // as #border_radius / #border_width).
+    const int32_t pill_radius = theme_manager_get_spacing("border_radius");
+    const int32_t pill_border_w = theme_manager_get_spacing("border_width");
 
     for (const auto* ext : sorted) {
         lv_obj_t* btn = lv_obj_create(extruder_selector_row_);
@@ -794,9 +799,8 @@ void TempGraphOverlay::rebuild_extruder_selector() {
         lv_obj_set_style_min_height(btn, pill_min_h, 0);
         lv_obj_set_style_pad_ver(btn, pill_pad_ver, 0);
         lv_obj_set_style_pad_hor(btn, pill_pad_hor, 0);
-        // Match the rounded-rectangle radius of the rest of the UI (preset
-        // buttons, dropdowns) rather than a full-circle pill.
-        lv_obj_set_style_radius(btn, ThemeManager::instance().current_palette().border_radius, 0);
+        // Rounded rectangle rather than a full-circle pill.
+        lv_obj_set_style_radius(btn, pill_radius, 0);
         lv_obj_set_style_bg_opa(btn, LV_OPA_COVER, 0);
         lv_obj_remove_flag(btn, LV_OBJ_FLAG_SCROLLABLE);
         lv_obj_add_flag(btn, LV_OBJ_FLAG_CLICKABLE);
@@ -807,10 +811,11 @@ void TempGraphOverlay::rebuild_extruder_selector() {
             is_active ? theme_manager_get_color("primary") : theme_manager_get_color("card_bg"), 0);
         // Inactive pills get an outline like the "Off" ghost button; the active
         // pill stays a solid primary fill with no border.
-        lv_obj_set_style_border_width(
-            btn, is_active ? 0 : ThemeManager::instance().current_palette().border_width, 0);
-        lv_obj_set_style_border_color(btn, theme_manager_get_color("border"), 0);
-        lv_obj_set_style_border_opa(btn, LV_OPA_COVER, 0);
+        lv_obj_set_style_border_width(btn, is_active ? 0 : pill_border_w, 0);
+        if (!is_active) {
+            lv_obj_set_style_border_color(btn, theme_manager_get_color("border"), 0);
+            lv_obj_set_style_border_opa(btn, LV_OPA_COVER, 0);
+        }
 
         lv_obj_t* label = lv_label_create(btn);
         // Compact pill label: show only the trailing number from "Nozzle N".


### PR DESCRIPTION
## Problem

On the temperature graph overlay, the extruder/tool selector pills are content-sized with a `font_small` label. On the Tiny breakpoint (480×320 — e.g. the Snapmaker U1, a 4-tool toolchanger) they render as ~18px single-digit chips that are hard to read and nearly impossible to tap accurately in the narrow 33% control column.

## Change

All in `TempGraphOverlay::rebuild_extruder_selector()`:

- **Touch size** — each pill now uses `flex_grow(1)` to share the control column equally, with a real `min_height` (`button_height_sm`) and a `font_body` digit centered in the pill (was `LV_SIZE_CONTENT` + `font_small`).
- **Squared corners** — radius switched from a full-circle pill to the theme's `border_radius`, matching the preset buttons and dropdowns.
- **Inactive outline** — inactive pills get the same border as the "Off" ghost button (`border_width` + `border` colour at full opacity); the active pill stays a solid `primary` fill.

All sizing comes from existing responsive design tokens, so it scales across breakpoints — no hardcoded values, no new event callbacks.

## Testing

Rendered in `--test` mode with a 4-tool toolchanger (`HELIX_MOCK_AMS=toolchanger`) at three breakpoints; the selector is legible and tappable at each, with no layout regression:

- Tiny (480×320)
- Medium (800×480)
- Large (1024×600)

## Screenshots

**Before — Tiny (480×320):**

<img width="480" height="320" alt="before-tiny-480x320" src="https://github.com/user-attachments/assets/18b0f4a0-9a75-45f5-8bb5-e09059f4423a" />


**After — Tiny (480×320):**

<img width="480" height="320" alt="after-tiny-480x320" src="https://github.com/user-attachments/assets/248cca69-6e93-4abe-bb54-9b54dd5caec0" />


**After — Medium (800×480):**

<img width="800" height="480" alt="after-medium-800x480" src="https://github.com/user-attachments/assets/e4199b42-11f1-495d-aeb3-787409e77aad" />


**After — Large (1024×600):**

<img width="1024" height="600" alt="after-large-1024x600" src="https://github.com/user-attachments/assets/28b6bc61-aa5e-47a5-ae48-8ab3d7e5ab47" />

