### PR TITLE
feat(portrait): stacked print_status layout for portrait screens

### DIFF
--- a/ui_xml/portrait/print_status_panel.xml
+++ b/ui_xml/portrait/print_status_panel.xml
@@ -1,0 +1,406 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2025-2026 356C LLC -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<component>
+  <!-- overlay_bg and overlay_text are theme-aware pairs defined in globals.xml -->
+  <consts>
+    <!-- metadata_clip_height: pad_bottom reservation used by the terminal-state -->
+    <!-- overlays (preparing/complete/cancelled/error/paused) so their badges don't -->
+    <!-- collide with the metadata strip. The clip/overlay themselves are now -->
+    <!-- height="content" and grow/shrink with display_message visibility. -->
+    <!-- Thumbnail vertical offset to clear metadata overlay at bottom -->
+    <percentage name="thumbnail_offset_y" value="-15%"/>
+  </consts>
+  <styles>
+    <!-- Fully transparent but still takes up layout space -->
+    <style name="invisible" opa="0"/>
+  </styles>
+  <!-- Print Status Panel - Active print monitoring with G-code 3D viewer -->
+  <!-- Portrait variant: same widgets and bindings as the base panel, stacked in a column. -->
+  <!-- Width is resolved by NavigationManager at push time; not set here. -->
+  <view name="print_status_panel"
+        extends="lv_obj" width="#overlay_width_transient" height="100%" align="right_mid" style_bg_opa="255"
+        style_bg_color="#card_bg" style_pad_all="0" style_border_width="0" flex_flow="column" clickable="true">
+    <!-- Header Bar. The E-stop is NOT a header child: header_height is responsive
+         (28 at MICRO, 32 at TINY) and a 44px circle does not fit inside it — it
+         centred at y=-2 and got clipped top and bottom (prestonbrown/helixscreen#1204). The
+         control that must never be unreachable does not get to depend on the
+         header's height, so it floats over the top-right corner instead, the same
+         way lock_screen.xml positions its estop_fab. -->
+    <header_bar name="overlay_header" title="Print Status" title_tag="Print Status"/>
+    <!-- Content Area (portrait: stacked column, viewer on top, controls below) -->
+    <lv_obj name="overlay_content"
+            width="100%" flex_grow="1" style_pad_left="#space_lg" style_pad_right="#space_lg" style_pad_top="0"
+            style_pad_bottom="#space_md" flex_flow="column" style_pad_gap="#space_md" scrollable="false">
+      <!-- Disable content when printer not connected or klippy not ready -->
+      <bind_state_if_not_eq subject="nav_buttons_enabled" state="disabled" ref_value="1"/>
+      <!-- ================================================================== -->
+      <!-- TOP SECTION: G-code Viewer / Thumbnail (fills remaining height)    -->
+      <!-- ================================================================== -->
+      <ui_card name="thumbnail_section"
+               width="100%" flex_grow="1" style_pad_all="0" style_margin_bottom="#space_md"
+               style_radius="#border_radius" style_clip_corner="true">
+        <!-- All children overlap as direct children of the card (matching print_file_detail pattern) -->
+
+        <!-- Pre-rendered gradient background (shown in thumbnail[0] and 2D[2] modes, hidden in 3D[1]) -->
+        <!-- Also hidden while the exclude-object overhead map covers the thumbnail section. -->
+        <ui_gradient_canvas name="gradient_background" width="100%" height="100%">
+          <bind_flag_if_eq subject="gcode_viewer_mode" flag="hidden" ref_value="1"/>
+          <bind_flag_if_eq subject="exclude_map_active" flag="hidden" ref_value="1"/>
+        </ui_gradient_canvas>
+
+        <!-- G-code Viewer (shown in 3D[1] and 2D[2] modes, hidden in thumbnail[0]) -->
+        <!-- Default hidden="true" prevents race during binding initialization -->
+        <gcode_viewer name="print_gcode_viewer" width="100%" height="100%" hidden="true">
+          <bind_flag_if_eq subject="gcode_viewer_mode" flag="hidden" ref_value="0"/>
+        </gcode_viewer>
+
+        <!-- Thumbnail image (shown in thumbnail[0] mode only, hidden in 3D[1] and 2D[2]) -->
+        <!-- Image source set programmatically via lv_image_set_src() when thumbnail available -->
+        <!-- Also hidden while the exclude-object overhead map covers the thumbnail section. -->
+        <lv_image name="print_thumbnail"
+                  width="100%" height="100%" align="center" inner_align="contain"
+                  style_translate_y="#thumbnail_offset_y">
+          <bind_flag_if_gt subject="gcode_viewer_mode" flag="hidden" ref_value="0"/>
+          <bind_flag_if_eq subject="exclude_map_active" flag="hidden" ref_value="1"/>
+        </lv_image>
+
+        <!-- Rotate hint icon (shown in 3D[1] mode only, hidden in thumbnail[0] and 2D[2]) -->
+        <lv_label name="rotate_hint"
+                  text="#icon_rotate_3d" style_text_font="mdi_icons_24" style_text_color="#text_muted"
+                  style_text_opa="180" align="top_right" style_translate_x="-12" style_translate_y="#space_md">
+          <bind_flag_if_not_eq subject="gcode_viewer_mode" flag="hidden" ref_value="1"/>
+        </lv_label>
+
+        <!-- PREPARING OVERLAY: Shown during pre-print operations (homing, etc) -->
+        <!-- pad_bottom reserves the metadata strip so spinner/heading/progress don't collide -->
+        <!-- with the Layer/Filename/ETA rows that metadata_overlay draws on top. -->
+        <lv_obj name="preparing_overlay"
+                width="100%" height="100%" align="center" style_bg_color="#overlay_bg" style_bg_opa="220"
+                style_radius="0" style_pad_all="#space_lg" style_pad_bottom="#metadata_clip_height" flex_flow="column"
+                style_flex_main_place="center" style_flex_cross_place="center" style_pad_gap="#space_md"
+                scrollable="false">
+          <bind_flag_if_eq subject="preparing_visible" flag="hidden" ref_value="0"/>
+          <spinner name="preparing_spinner" size="lg"/>
+          <text_heading name="preparing_operation_label"
+                        width="100%" bind_text="print_start_message" text="Preparing..." translation_tag="Preparing..."
+                        style_text_color="#text" style_text_align="center"/>
+          <progress_bar name="preparing_progress_bar" width="80%" bind_value="preparing_progress"/>
+          <text_small name="preparing_eta"
+                      bind_text="print_start_time_left" style_text_color="#text" style_text_opa="180"/>
+        </lv_obj>
+
+        <!-- Objects list button: top-left corner, visible only when multi-object print -->
+        <lv_obj name="btn_objects"
+                width="36" height="36" align="top_left" style_translate_x="#space_md" style_translate_y="#space_md"
+                style_bg_color="#card_bg" style_bg_opa="180" style_radius="18" clickable="true" style_pad_all="0"
+                scrollable="false">
+          <bind_flag_if_eq subject="exclude_objects_available" flag="hidden" ref_value="0"/>
+          <lv_label text="#icon_view_list" style_text_font="mdi_icons_24" style_text_color="#text_muted" align="center"/>
+          <event_cb trigger="clicked" callback="on_print_status_objects"/>
+        </lv_obj>
+
+        <!-- View mode toggle: switches between progress (ghost layers) and complete view -->
+        <!-- Position shifts right when objects button is visible (managed in C++) -->
+        <lv_obj name="btn_view_toggle"
+                width="36" height="36" align="top_left" style_translate_x="#space_md" style_translate_y="#space_md"
+                style_bg_color="#card_bg" style_bg_opa="180" style_radius="18" clickable="true" style_pad_all="0"
+                scrollable="false">
+          <bind_flag_if_eq subject="gcode_viewer_mode" flag="hidden" ref_value="0"/>
+          <lv_label name="btn_view_toggle_icon"
+                    bind_text="view_toggle_icon" style_text_font="mdi_icons_24" style_text_color="#text_muted"
+                    align="center"/>
+          <event_cb trigger="clicked" callback="on_view_toggle"/>
+        </lv_obj>
+
+        <!-- PRINT COMPLETE OVERLAY: Shown when print finishes successfully -->
+        <!-- Single derived subject show_complete_overlay = (outcome==COMPLETE && !dismissed). -->
+        <!-- Two independent bind_flag observers on hidden raced at startup (L042). -->
+        <lv_obj name="print_complete_overlay"
+                width="100%" height="100%" align="top_mid" style_radius="0" style_pad_all="#space_lg"
+                style_pad_bottom="#metadata_clip_height" flex_flow="column" style_flex_main_place="center"
+                style_flex_cross_place="center" style_flex_track_place="center" style_pad_gap="#space_sm"
+                scrollable="false" clickable="true" hidden="true">
+          <bind_flag_if_eq subject="show_complete_overlay" flag="hidden" ref_value="0"/>
+          <event_cb trigger="clicked" callback="on_print_status_dismiss_overlay"/>
+          <!-- Green success badge with checkmark (animated on appearance) -->
+          <!-- Uses ui_button for auto-contrast text via update_button_text_contrast() -->
+          <ui_button name="success_badge"
+                     width="content" height="content" variant="success" icon="check_circle" text="Print Complete!"
+                     translation_tag="Print Complete!" clickable="false" focusable="false" style_radius="#space_lg"
+                     style_pad_left="#space_md" style_pad_right="#space_md" style_pad_top="#space_sm"
+                     style_pad_bottom="#space_sm"/>
+        </lv_obj>
+
+        <!-- PRINT CANCELLED OVERLAY: shown via show_cancelled_overlay (see COMPLETE above). -->
+        <lv_obj name="print_cancelled_overlay"
+                width="100%" height="100%" align="top_mid" style_radius="0" style_pad_all="#space_lg"
+                style_pad_bottom="#metadata_clip_height" flex_flow="column" style_flex_main_place="center"
+                style_flex_cross_place="center" style_flex_track_place="center" style_pad_gap="#space_sm"
+                scrollable="false" clickable="true" hidden="true">
+          <bind_flag_if_eq subject="show_cancelled_overlay" flag="hidden" ref_value="0"/>
+          <event_cb trigger="clicked" callback="on_print_status_dismiss_overlay"/>
+          <!-- Orange warning badge with cancel icon (animated on appearance) -->
+          <!-- Uses ui_button for auto-contrast text via update_button_text_contrast() -->
+          <ui_button name="cancel_badge"
+                     width="content" height="content" variant="warning" icon="cancel" text="Print Cancelled"
+                     translation_tag="Print Cancelled" clickable="false" focusable="false" style_radius="#space_lg"
+                     style_pad_left="#space_md" style_pad_right="#space_md" style_pad_top="#space_sm"
+                     style_pad_bottom="#space_sm"/>
+        </lv_obj>
+
+        <!-- PRINT ERROR OVERLAY: shown via show_error_overlay (see COMPLETE above). -->
+        <lv_obj name="print_error_overlay"
+                width="100%" height="100%" align="top_mid" style_radius="0" style_pad_all="#space_lg"
+                style_pad_bottom="#metadata_clip_height" flex_flow="column" style_flex_main_place="center"
+                style_flex_cross_place="center" style_flex_track_place="center" style_pad_gap="#space_sm"
+                scrollable="false" clickable="true" hidden="true">
+          <bind_flag_if_eq subject="show_error_overlay" flag="hidden" ref_value="0"/>
+          <event_cb trigger="clicked" callback="on_print_status_dismiss_overlay"/>
+          <!-- Red danger badge with alert icon (animated on appearance) -->
+          <!-- Uses ui_button for auto-contrast text via update_button_text_contrast() -->
+          <ui_button name="error_badge"
+                     width="content" height="content" variant="danger" icon="alert_circle" text="Print Failed"
+                     translation_tag="Print Failed" clickable="false" focusable="false" style_radius="#space_lg"
+                     style_pad_left="#space_md" style_pad_right="#space_md" style_pad_top="#space_sm"
+                     style_pad_bottom="#space_sm"/>
+        </lv_obj>
+
+        <!-- PRINT PAUSED OVERLAY: shown while print is in PAUSED state. Driven by   -->
+        <!-- show_paused_overlay (1 when print_state_enum==PAUSED). Unlike the three -->
+        <!-- terminal overlays above, this is NOT dismissible — the badge stays up  -->
+        <!-- until the print resumes or terminates, so the paused condition is      -->
+        <!-- always visually obvious. Resume/Cancel controls live in the right pane.-->
+        <!-- Title is static; reason is an optional second label hidden when         -->
+        <!-- print_pause_reason_visible == 0 (set by recompute_paused_overlay_*).    -->
+        <lv_obj name="print_paused_overlay"
+                width="100%" height="100%" align="top_mid" style_radius="0" style_pad_all="#space_lg"
+                style_pad_bottom="#metadata_clip_height" flex_flow="column" style_flex_main_place="center"
+                style_flex_cross_place="center" style_flex_track_place="center" scrollable="false" clickable="false"
+                hidden="true">
+          <bind_flag_if_eq subject="show_paused_overlay" flag="hidden" ref_value="0"/>
+          <!-- ui_button styled container (variant="primary" applies bg + auto-contrast on  -->
+          <!-- child labels). Two stacked labels inside: a title that's always shown and a  -->
+          <!-- reason that's hidden when print_pause_reason_visible==0. Toggling visibility  -->
+          <!-- of an independent widget makes the parent flex-column grow declaratively —    -->
+          <!-- avoiding the dynamic LV_SIZE_CONTENT cascade issue we hit with a single       -->
+          <!-- multi-line label that changes line count after the badge was already laid out.-->
+          <ui_button name="paused_badge"
+                     width="content" height="content" variant="primary" layout="row" style_min_height="0"
+                     clickable="false" focusable="false" style_radius="#space_lg" style_pad_left="#space_md"
+                     style_pad_right="#space_md" style_pad_top="#space_sm" style_pad_bottom="#space_sm"
+                     style_pad_gap="#space_sm">
+            <lv_label text="#icon_pause" style_text_font="mdi_icons_24"/>
+            <lv_obj width="content"
+                    height="content" style_pad_all="0" style_pad_gap="0" style_border_width="0" style_bg_opa="0"
+                    flex_flow="column" style_flex_cross_place="center" scrollable="false">
+              <lv_label text="Print Paused" translation_tag="Print Paused" style_text_align="center"/>
+              <lv_label name="paused_badge_reason" bind_text="print_pause_reason" style_text_align="center">
+                <bind_flag_if_eq subject="print_pause_reason_visible" flag="hidden" ref_value="0"/>
+              </lv_label>
+            </lv_obj>
+          </ui_button>
+        </lv_obj>
+
+        <!-- Metadata container - content-sized at bottom, overlaying thumbnail. -->
+        <!-- Grows when the optional M117 (display_message) row becomes visible. -->
+        <lv_obj name="metadata_clip"
+                width="100%" height="content" style_radius="0" style_pad_all="0" align="bottom_mid" scrollable="false">
+          <!-- Inner overlay with semi-transparent background and rounded corners -->
+          <lv_obj name="metadata_overlay"
+                  width="100%" height="content" align="bottom_mid" style_bg_opa="160" style_radius="#border_radius"
+                  style_pad_left="#space_sm" style_pad_right="#space_sm" style_pad_top="#space_md"
+                  style_pad_bottom="#space_md" style_pad_gap="#space_xs" flex_flow="column" scrollable="false">
+            <!-- Print Progress Bar (invisible during pre-print operations, but keeps layout space) -->
+            <progress_bar name="print_progress" bind_value="print_progress">
+              <bind_style name="invisible" subject="preparing_visible" ref_value="1"/>
+            </progress_bar>
+            <!-- Layer Progress (Layer X / Y) + Objects Count -->
+            <lv_obj width="100%"
+                    height="content" style_pad_all="0" flex_flow="row" style_flex_main_place="space_between"
+                    style_flex_cross_place="center" scrollable="false">
+              <text_small name="layer_progress_label"
+                          text="Layer 0 / 0" bind_text="print_layer_text" style_text_align="left"/>
+              <text_small name="objects_count_label" text="" bind_text="print_objects_text">
+                <bind_flag_if_eq subject="exclude_objects_available" flag="hidden" ref_value="0"/>
+              </text_small>
+              <text_small name="filament_used_label" text="" bind_text="print_filament_used_text"/>
+            </lv_obj>
+            <!-- File Name (shared subject from ActivePrintMediaManager) -->
+            <text_body name="file_name"
+                       width="100%" text="benchy.gcode" bind_text="print_display_filename" style_text_align="left"
+                       long_mode="scroll_circular"/>
+            <!-- Status Row: Time/Progress -->
+            <lv_obj width="100%"
+                    height="content" style_pad_all="0" flex_flow="row" style_flex_main_place="space_between"
+                    style_flex_cross_place="center" scrollable="false">
+              <!-- Time display: elapsed / remaining with labels -->
+              <lv_obj height="content"
+                      flex_grow="1" style_pad_all="0" flex_flow="row" style_flex_main_place="start"
+                      style_flex_cross_place="center" scrollable="false">
+                <text_small name="print_elapsed" text="0m" bind_text="print_elapsed"/>
+                <text_small text=" elapsed · " translation_tag=" elapsed · "/>
+                <text_small name="print_remaining" text="0m" bind_text="print_remaining"/>
+                <text_small text=" left" translation_tag=" left"/>
+                <text_small name="print_eta" text="" bind_text="print_eta" style_pad_left="#space_xs"/>
+              </lv_obj>
+              <text_small name="print_percent" text="0%" bind_text="print_progress_text"/>
+            </lv_obj>
+            <!-- Klipper display_status.message (M117) — collapses to zero height -->
+            <!-- when empty. Shown during pre-print too: the collector's phase -->
+            <!-- label is a separate subject (print_start_message) rendered by -->
+            <!-- preparing_overlay above, so the two do not duplicate. -->
+            <text_small name="display_message"
+                        width="100%" bind_text="display_message" style_text_align="left" long_mode="scroll_circular"
+                        style_text_color="#text_muted" hidden="true">
+              <bind_flag_if_eq subject="display_message_visible" flag="hidden" ref_value="0"/>
+            </text_small>
+          </lv_obj>
+          <!-- metadata_overlay -->
+        </lv_obj>
+        <!-- metadata_clip -->
+
+      </ui_card>
+
+      <!-- ================================================================== -->
+      <!-- BOTTOM SECTION: Controls (content height, full width)          -->
+      <!-- ================================================================== -->
+      <lv_obj name="controls_section"
+              width="100%" height="content" style_pad_all="0" scrollable="false" flex_flow="column"
+              style_pad_gap="#space_md">
+
+        <!-- Unified Temperature Card (nozzle + bed + optional chamber) -->
+        <temp_card_unified name="temp_card"/>
+
+        <!-- Speed / Flow indicators (hidden on TINY and SMALL breakpoints) -->
+        <!-- Tap opens Tune overlay (same as Tune button) -->
+        <lv_obj name="speed_flow_row"
+                width="100%" height="content" style_pad_left="#space_md" style_pad_right="#space_md" style_pad_top="0"
+                flex_flow="row" style_flex_cross_place="center" style_pad_gap="#space_sm" scrollable="false"
+                clickable="true">
+          <bind_flag_if_eq subject="ui_breakpoint" flag="hidden" ref_value="1"/>
+          <bind_flag_if_eq subject="ui_breakpoint" flag="hidden" ref_value="2"/>
+          <event_cb trigger="clicked" callback="on_print_status_tune"/>
+          <text_small text="Speed" clickable="false" event_bubble="true"/>
+          <text_small name="speed_value" bind_text="print_speed_text" clickable="false" event_bubble="true"/>
+          <text_small text=" · " clickable="false" event_bubble="true"/>
+          <text_small text="Flow" clickable="false" event_bubble="true"/>
+          <text_small name="flow_value" bind_text="print_flow_text" clickable="false" event_bubble="true"/>
+        </lv_obj>
+
+        <!-- Filament & AMS Status Row (side-by-side) -->
+        <lv_obj name="filament_ams_status_row"
+                width="100%" height="content" style_pad_left="#space_md" style_pad_right="#space_md"
+                style_pad_top="#space_xs" flex_flow="row" style_flex_main_place="space_between"
+                style_flex_cross_place="center" scrollable="false">
+          <!-- Filament Sensor Status (hidden if no sensors) -->
+          <lv_obj name="filament_status_row"
+                  width="content" height="content" style_pad_all="0" flex_flow="row" style_flex_cross_place="center"
+                  style_pad_gap="#space_sm">
+            <bind_flag_if_eq subject="filament_sensor_count" flag="hidden" ref_value="0"/>
+            <!-- Scoped to the active print's tools (lane truth) — see FIX B. -->
+            <filament_sensor_indicator subject="filament_runout_scoped"/>
+          </lv_obj>
+          <!-- Tool Change Progress (hidden when no multi-color swaps expected) -->
+          <lv_obj name="toolchange_status"
+                  width="content" height="content" style_pad_all="0" flex_flow="row" style_flex_cross_place="center"
+                  style_pad_gap="#space_xs">
+            <bind_flag_if_eq subject="toolchange_visible" flag="hidden" ref_value="0"/>
+            <icon src="swap_vertical" size="sm" variant="muted"/>
+            <text_small bind_text="toolchange_text"/>
+          </lv_obj>
+          <!-- AMS Current Tool Status (hidden if no AMS) -->
+          <lv_obj name="ams_status_row"
+                  width="content" height="content" style_pad_all="0" flex_flow="row" style_flex_cross_place="center"
+                  style_pad_gap="#space_sm">
+            <bind_flag_if_eq subject="ams_slot_count" flag="hidden" ref_value="0"/>
+            <ams_current_tool name="ams_current_tool_indicator"/>
+          </lv_obj>
+        </lv_obj>
+
+        <!-- Fan info row: part / hotend / aux speeds, click → fan control overlay. -->
+        <!-- Visibility driven by print_status_fans_fit subject (computed in C++). -->
+        <print_status_fan_row name="print_status_fan_row"/>
+
+        <!-- Control Buttons (flex_grow pushes to bottom via main_place=end) -->
+        <lv_obj name="button_grid"
+                width="100%" height="content" style_pad_all="0" scrollable="false" flex_flow="column"
+                style_flex_main_place="end" style_flex_cross_place="center" style_pad_gap="#space_sm">
+          <!-- Row 1: Light, Timelapse (conditional), Pause -->
+          <lv_obj width="100%"
+                  height="content" style_pad_all="0" scrollable="false" flex_flow="row" style_flex_main_place="center"
+                  style_flex_cross_place="center" style_pad_gap="#space_sm">
+            <ui_button name="btn_light"
+                       height="#button_height_lg" flex_grow="1" text="Light" translation_tag="Light"
+                       bind_icon="light_button_icon" label_hidden_if_bp_eq="1">
+              <event_cb trigger="clicked" callback="on_print_status_light"/>
+              <bind_flag_if_eq subject="led_controllable" flag="hidden" ref_value="0"/>
+              <bind_state_if_eq subject="led_command_in_flight" state="disabled" ref_value="1"/>
+            </ui_button>
+            <!-- Timelapse button: only visible when Moonraker-Timelapse plugin installed -->
+            <ui_button name="btn_timelapse"
+                       height="#button_height_lg" flex_grow="1" bind_icon="timelapse_button_icon"
+                       bind_text="timelapse_button_label" label_hidden_if_bp_eq="1">
+              <event_cb trigger="clicked" callback="on_print_status_timelapse"/>
+              <bind_flag_if_eq subject="printer_has_timelapse" flag="hidden" ref_value="0"/>
+              <bind_state_if_eq subject="print_controls_enabled" state="disabled" ref_value="0"/>
+            </ui_button>
+            <ui_button name="btn_pause"
+                       height="#button_height_lg" flex_grow="1" style_max_width="50%"
+                       bind_icon="print_control_primary_icon" bind_text="print_control_primary_label"
+                       label_hidden_if_bp_eq="1">
+              <event_cb trigger="clicked" callback="on_print_control_primary"/>
+              <bind_state_if_eq subject="print_control_primary_enabled" state="disabled" ref_value="0"/>
+            </ui_button>
+          </lv_obj>
+
+          <!-- Row 2: Tune, Cancel -->
+          <lv_obj width="100%"
+                  height="content" style_pad_all="0" scrollable="false" flex_flow="row" style_flex_main_place="center"
+                  style_flex_cross_place="center" style_pad_gap="#space_sm">
+            <ui_button name="btn_tune"
+                       height="#button_height_lg" flex_grow="1" icon="tune" text="Tune" translation_tag="Tune">
+              <event_cb trigger="clicked" callback="on_print_status_tune"/>
+              <bind_state_if_eq subject="print_controls_enabled" state="disabled" ref_value="0"/>
+            </ui_button>
+            <!-- Cancel button: visible only during active print (outcome == NONE/0) -->
+            <ui_button name="btn_cancel"
+                       height="#button_height_lg" flex_grow="1" variant="danger" icon="stop" text="Cancel"
+                       translation_tag="Cancel">
+              <bind_flag_if_not_eq subject="print_outcome" flag="hidden" ref_value="0"/>
+              <bind_state_if_eq subject="print_control_stop_enabled" state="disabled" ref_value="0"/>
+              <event_cb trigger="clicked" callback="on_print_control_stop"/>
+            </ui_button>
+            <!-- Reprint button: shown for any terminal state (complete/cancelled/error) -->
+            <ui_button name="btn_reprint"
+                       height="#button_height_lg" flex_grow="1" icon="refresh" text="Reprint" translation_tag="Reprint"
+                       hidden="true">
+              <bind_flag_if_eq subject="print_outcome" flag="hidden" ref_value="0"/>
+              <event_cb trigger="clicked" callback="on_print_status_reprint"/>
+            </ui_button>
+          </lv_obj>
+        </lv_obj>
+
+        <!-- Plugin injection point: widgets from plugins appear here -->
+        <!-- Plugins can inject print monitoring widgets, sensor readouts, etc. -->
+        <lv_obj name="print_status_extras"
+                width="100%" height="content" style_pad_all="0" flex_flow="column" style_pad_gap="#space_md"/>
+      </lv_obj>
+    </lv_obj>
+
+    <!-- E-Stop FAB — floats over the top-right corner, outside the flex column.
+         ignore_layout keeps the column layout from positioning it, so align
+         applies and the button keeps a full 44px touch target at every
+         breakpoint regardless of how short the header is. Declared last so it
+         draws above the content it overlaps. -->
+    <lv_button name="estop_fab"
+               width="44" height="44" ignore_layout="true" align="top_right" style_translate_x="-#space_sm"
+               style_translate_y="#space_sm" style_radius="9999" style_bg_color="#danger" style_pad_all="0">
+      <!-- Explicit color, not variant="primary": a variant resolves to the theme
+           primary (blue), which is near-invisible on the danger-red circle. The
+           header_bar this replaced defaulted its icon to #text. -->
+      <icon src="alert_octagon" size="md" color="#text" align="center"/>
+      <event_cb trigger="clicked" callback="emergency_stop_clicked"/>
+    </lv_button>
+  </view>
+</component>


### PR DESCRIPTION
First panel of the per-panel portrait sweep, following #1110's foundation.

## Problem

`print_status_panel.xml` is a two-column flex row (viewer 5/9, controls 4/9). On narrow portrait screens both columns get crushed: temperature values clip, "Speed 100% · Flow 100%" truncates mid-word, and the five control buttons squeeze into unreadable slivers ("Ligh", "Canc"). A chunk of width is also wasted because the root view uses `#overlay_panel_width` (screen − nav_width − gap), which reserves room for the *side* nav that portrait doesn't have — portrait's navbar is along the bottom.

## Change

Adds `ui_xml/portrait/print_status_panel.xml`. Every widget name, binding, subject, and event callback is identical to the base panel — only the container structure changes:

- `overlay_content`: flex row → **column** (viewer on top, controls below)
- `thumbnail_section`: full width, `flex_grow="1"` for the remaining height
- `controls_section` and `button_grid`: `width="100%"`, `height="content"`
- root view: `width="100%"` instead of `#overlay_panel_width`
- `overlay_content` gains `style_pad_bottom="#space_md"` so the last button row clears the screen edge

Thanks to the portrait family fallback from `resolve_xml_path`, this single file serves `portrait`, `tiny_portrait`, and `micro_portrait`.

## Verification

- `make lint-xml` → 324 files, 0 errors, 0 warnings
- `make test-run` (full suite) → all shards pass except one **pre-existing upstream flake**, `ams edit overlay reclaims its widget tree on close and rebuilds on reopen` (`CHECK( root2 != root1 )`, heap-address reuse at `test_ams_edit_overlay_views.cpp:1742`). Verified unrelated to this change: it fails identically 3/3 runs on clean `main` with this file absent, and 5/5 on the branch. Same flake #1110 saw.
- Targeted suites `[theme],[layout],[xml]` → 3896 assertions / 191 cases, all passing
- Landscape cannot regress — the base file is untouched, the diff is purely additive (one new file)

### Breakpoint verification

Checked in the emulator (`--test -p print-status`) at three portrait breakpoints; screenshots attached in a follow-up comment.

- **320×1480** (Waveshare 11.9", the target panel) — before: viewer and controls each ~150px wide, temps reduced to bare icons, speed/flow cut off, buttons clipped to "Ligh"/"Canc". After: full-width viewer with metadata strip, `42.7 / 220°C`-style temps fully legible, complete "Speed 100% · Flow 100%" row, five full-width labeled buttons.
- **480×800** — same stacked structure with comfortable spacing; nozzle/bed/chamber rows and both button rows fully readable.
- **272×480** (smallest portrait class, reached via the family fallback) — degrades gracefully; all content still legible, nothing clipped at the edges.

Next in the sweep: `print_select`, `print_tune`, `controls`, `ams`, then the home dashboard cards.