### PR TITLE
feat(portrait): stack the speed and flow sections in print_tune

### DIFF
--- a/ui_xml/portrait/print_tune_panel.xml
+++ b/ui_xml/portrait/print_tune_panel.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2025-2026 356C LLC -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<component>
+  <!-- Styles for Z-offset step amount radio buttons (L040: TWO bind_styles per button) -->
+  <styles>
+    <style name="z_step_selected" bg_color="#primary" bg_opa="255"/>
+    <style name="z_step_unselected" bg_color="#primary" bg_opa="40"/>
+  </styles>
+  <!-- Print Tuning Panel: Speed and Flow adjustment during active print -->
+  <view name="print_tune_panel" extends="overlay_panel" title="Print Tuning" title_tag="Print Tuning">
+    <!-- Content Area -->
+    <lv_obj name="overlay_content"
+            width="100%" flex_grow="1" style_pad_left="#space_lg" style_pad_right="#space_lg"
+            style_pad_bottom="#space_lg" style_pad_top="0" flex_flow="column" style_flex_main_place="start"
+            style_pad_gap="#space_md">
+      <!-- Disable content when printer not connected or klippy not ready -->
+      <bind_state_if_not_eq subject="nav_buttons_enabled" state="disabled" ref_value="1"/>
+      <!-- Speed + Flow (portrait: stacked, each full width) -->
+      <lv_obj name="speed_flow_row"
+              width="100%" height="content" style_pad_all="0" scrollable="false" flex_flow="column"
+              style_pad_gap="#space_lg" overflow_visible="true">
+        <!-- Speed Control (top) -->
+        <lv_obj name="speed_section"
+                width="100%" height="content" style_pad_all="0" flex_flow="column" style_pad_gap="#space_sm"
+                overflow_visible="true" scrollable="false">
+          <lv_obj width="100%"
+                  height="content" style_pad_all="0" scrollable="false" flex_flow="row" style_flex_cross_place="center"
+                  style_pad_gap="#space_sm">
+            <text_small text="Print Speed" translation_tag="Print Speed"/>
+            <text_heading name="speed_display" bind_text="tune_speed_display"/>
+            <lv_obj height="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
+            <text_small name="actual_speed_display" bind_text="tune_actual_speed_display" style_text_color="#text_muted"/>
+          </lv_obj>
+          <lv_obj width="100%"
+                  height="content" style_pad_all="0" flex_flow="row" style_pad_gap="#space_xxs" scrollable="false">
+            <ui_button height="#button_height_sm" flex_grow="1" text="-10">
+              <event_cb trigger="clicked" callback="on_tune_speed_adjust" user_data="-10"/>
+            </ui_button>
+            <ui_button height="#button_height_sm" flex_grow="1" text="-5">
+              <event_cb trigger="clicked" callback="on_tune_speed_adjust" user_data="-5"/>
+            </ui_button>
+            <ui_button height="#button_height_sm" flex_grow="1" text="+5">
+              <event_cb trigger="clicked" callback="on_tune_speed_adjust" user_data="5"/>
+            </ui_button>
+            <ui_button height="#button_height_sm" flex_grow="1" text="+10">
+              <event_cb trigger="clicked" callback="on_tune_speed_adjust" user_data="10"/>
+            </ui_button>
+          </lv_obj>
+        </lv_obj>
+        <!-- Flow Control (bottom) -->
+        <lv_obj name="flow_section"
+                width="100%" height="content" style_pad_all="0" flex_flow="column" style_pad_gap="#space_sm"
+                overflow_visible="true" scrollable="false">
+          <lv_obj width="100%"
+                  height="content" style_pad_all="0" scrollable="false" flex_flow="row" style_flex_cross_place="center"
+                  style_pad_gap="#space_sm">
+            <text_small text="Flow Rate" translation_tag="Flow Rate"/>
+            <text_heading name="flow_display" bind_text="tune_flow_display"/>
+            <lv_obj height="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
+            <text_small name="actual_flow_display" bind_text="tune_actual_flow_display" style_text_color="#text_muted"/>
+          </lv_obj>
+          <lv_obj width="100%"
+                  height="content" style_pad_all="0" flex_flow="row" style_pad_gap="#space_xxs" scrollable="false">
+            <ui_button height="#button_height_sm" flex_grow="1" text="-10">
+              <event_cb trigger="clicked" callback="on_tune_flow_adjust" user_data="-10"/>
+            </ui_button>
+            <ui_button height="#button_height_sm" flex_grow="1" text="-5">
+              <event_cb trigger="clicked" callback="on_tune_flow_adjust" user_data="-5"/>
+            </ui_button>
+            <ui_button height="#button_height_sm" flex_grow="1" text="+5">
+              <event_cb trigger="clicked" callback="on_tune_flow_adjust" user_data="5"/>
+            </ui_button>
+            <ui_button height="#button_height_sm" flex_grow="1" text="+10">
+              <event_cb trigger="clicked" callback="on_tune_flow_adjust" user_data="10"/>
+            </ui_button>
+          </lv_obj>
+        </lv_obj>
+      </lv_obj>
+      <!-- Reset Speed & Flow Button -->
+      <ui_button name="btn_reset"
+                 width="100%" icon="refresh" text="Reset Speed &amp; Flow to 100%"
+                 translation_tag="Reset Speed &amp; Flow to 100%">
+        <event_cb trigger="clicked" callback="on_tune_reset_clicked"/>
+      </ui_button>
+      <!-- Z-Offset Baby Stepping Section (flex_grow claims remaining space, content aligned to bottom) -->
+      <lv_obj name="z_offset_section"
+              width="100%" height="content" style_pad_all="0" flex_flow="column" style_pad_gap="#space_xs"
+              scrollable="false">
+        <!-- Header Row -->
+        <lv_obj width="100%"
+                height="content" style_pad_all="0" scrollable="false" flex_flow="row"
+                style_flex_main_place="space_between" style_flex_cross_place="center">
+          <text_body text="Z-Offset"/>
+          <text_heading name="z_offset_display" bind_text="tune_z_offset_display"/>
+        </lv_obj>
+
+        <!-- Indicator (left) + Controls (right) side-by-side -->
+        <lv_obj width="100%"
+                height="content" style_pad_all="0" flex_flow="row" style_pad_gap="#space_sm" scrollable="false">
+          <!-- Nozzle-over-bed visual indicator -->
+          <z_offset_indicator name="z_offset_indicator" width="170"/>
+          <!-- Controls column: amount buttons row with direction buttons stacked on the right -->
+          <lv_obj height="content"
+                  flex_grow="1" style_pad_all="0" flex_flow="column" style_pad_gap="#space_xxs" scrollable="false">
+            <!-- Amount selectors (left) + direction buttons (right) -->
+            <lv_obj width="100%"
+                    height="content" style_pad_all="0" flex_flow="row" style_pad_gap="#space_sm"
+                    style_flex_cross_place="center" scrollable="false">
+              <!-- Amount selector buttons (radio-style: one active at a time) -->
+              <lv_obj height="content"
+                      flex_grow="1" style_pad_all="0" flex_flow="row" style_pad_gap="#space_xxs" scrollable="false">
+                <ui_button height="#button_height_sm" flex_grow="1" text="0.05">
+                  <bind_style name="z_step_selected" subject="z_step_0_active" ref_value="1"/>
+                  <bind_style name="z_step_unselected" subject="z_step_0_active" ref_value="0"/>
+                  <event_cb trigger="clicked" callback="on_tune_z_step" user_data="0"/>
+                </ui_button>
+                <ui_button height="#button_height_sm" flex_grow="1" text="0.025">
+                  <bind_style name="z_step_selected" subject="z_step_1_active" ref_value="1"/>
+                  <bind_style name="z_step_unselected" subject="z_step_1_active" ref_value="0"/>
+                  <event_cb trigger="clicked" callback="on_tune_z_step" user_data="1"/>
+                </ui_button>
+                <ui_button height="#button_height_sm" flex_grow="1" text="0.01">
+                  <bind_style name="z_step_selected" subject="z_step_2_active" ref_value="1"/>
+                  <bind_style name="z_step_unselected" subject="z_step_2_active" ref_value="0"/>
+                  <event_cb trigger="clicked" callback="on_tune_z_step" user_data="2"/>
+                </ui_button>
+                <ui_button height="#button_height_sm" flex_grow="1" text="0.005">
+                  <bind_style name="z_step_selected" subject="z_step_3_active" ref_value="1"/>
+                  <bind_style name="z_step_unselected" subject="z_step_3_active" ref_value="0"/>
+                  <event_cb trigger="clicked" callback="on_tune_z_step" user_data="3"/>
+                </ui_button>
+              </lv_obj>
+              <!-- Direction buttons stacked vertically -->
+              <lv_obj width="90"
+                      height="content" style_pad_all="0" flex_flow="column" style_pad_gap="#space_xxs"
+                      scrollable="false">
+                <ui_button width="100%" icon="arrow_up" bind_icon="tune_z_farther_icon">
+                  <event_cb trigger="clicked" callback="on_tune_z_adjust" user_data="1"/>
+                </ui_button>
+                <ui_button width="100%" icon="arrow_down" bind_icon="tune_z_closer_icon">
+                  <event_cb trigger="clicked" callback="on_tune_z_adjust" user_data="-1"/>
+                </ui_button>
+              </lv_obj>
+            </lv_obj>
+            <!-- Help text -->
+            <text_small text="Closer = more squish | Farther = less squish"
+                        translation_tag="Closer = more squish | Farther = less squish"/>
+          </lv_obj>
+        </lv_obj>
+        <text_small name="z_offset_help_text_manual"
+                    text="Temporary adjustment for this print, unless saved on Controls panel"
+                    translation_tag="Temporary adjustment for this print, unless saved on Controls panel" hidden="true">
+          <bind_flag_if_eq subject="z_offset_can_save" flag="hidden" ref_value="0"/>
+        </text_small>
+        <text_small name="z_offset_help_text_auto"
+                    text="Z-offset is auto-saved by firmware" translation_tag="Z-offset is auto-saved by firmware">
+          <bind_flag_if_eq subject="z_offset_can_save" flag="hidden" ref_value="1"/>
+        </text_small>
+      </lv_obj>
+    </lv_obj>
+  </view>
+</component>


### PR DESCRIPTION
Panel 2 of the portrait sweep, per the split in #1203. Built on the merged prerequisites.

## Problem

`speed_flow_row` lays Speed and Flow side by side. That's a landscape shape: in portrait each section gets roughly half of an already narrow content area, so the four adjust buttons per section squeeze to about 28px each.

## Change

Adds `ui_xml/portrait/print_tune_panel.xml`, regenerated from the current base. Container change only: `speed_flow_row` flips from a row to a column, both sections get `width="100%"`. Same widgets, names, bindings and callbacks, nothing hidden or resized. Variant parity and responsive-token gates pass.

print_tune has no C++ geometry coupling (no `lv_obj_get_*` reads against its containers), so no seam work was needed.

## Verification

Measured with `helix-screen ctl geom speed_flow_row` on the rebuilt binary:

| Size | speed_section | flow_section | row overflow |
|---|---|---|---|
| 320x1480 | w=304 | w=304 | 0 |
| 480x800 | w=448 | w=448 | 0 |
| 272x480 | w=256 | w=256 | 0 |
| 800x480 (landscape control) | w=338 | w=338, side by side | 0 |

Before, at 320x1480, each section was w=121.

Known and not addressed here (sizing decision, not an orientation change): the z-offset help text is wider than the portrait content box, so "Closer = more squish | Farther = less squish" and "Temporary adjustment for this print..." clip on narrow screens.

Screenshots in a follow-up comment: 320x1480, 480x800, 272x480, plus the landscape control.