### PR TITLE
fix(cfs): honor community K2 Box command contract

### DIFF
--- a/docs/devel/FILAMENT_MANAGEMENT.md
+++ b/docs/devel/FILAMENT_MANAGEMENT.md
@@ -2054,7 +2054,7 @@ The `box` Klipper object is shared by several firmwares that agree on almost not
 |----------------|--------------------|---------------|-----------------|
 | K2, K2 Pro, K2 Plus (built-in CFS) | Creality K2 firmware | `CR_BOX_*` primitives + `BOX_SAVE_FAN`/`BOX_MODE_WAIT` envelope | `PrinterDetector::is_creality_k1() == false` |
 | K1, K1C, K1 Max (official CFS upgrade ≥ v2.3.5.33) | Creality K1 CFS upgrade firmware | Plain `BOX_*` primitives, no fan-save/mode-wait | `PrinterDetector::is_creality_k1() == true` |
-| K2 Plus on a community Kalico port | `Jacob10383/kalico` + a reimplemented `box.py` | High-level `BOX_LOAD SLOT=` / `BOX_UNLOAD` / `T<n> FLUSH=` | `fluidd_widget_version` in the box payload (the module's own identity marker) |
+| K2 Plus on a community Kalico port | `Jacob10383/kalico` + a reimplemented `box.py` | High-level bare `T<n>` / `BOX_UNLOAD` | `fluidd_widget_version` in the box payload (the module's own identity marker) |
 
 **Axis 2 — box schema** (`CfsSchema`), detected per-payload by `AmsBackendCfs::detect_schema()`:
 

--- a/docs/devel/FILAMENT_MANAGEMENT.md
+++ b/docs/devel/FILAMENT_MANAGEMENT.md
@@ -2054,7 +2054,7 @@ The `box` Klipper object is shared by several firmwares that agree on almost not
 |----------------|--------------------|---------------|-----------------|
 | K2, K2 Pro, K2 Plus (built-in CFS) | Creality K2 firmware | `CR_BOX_*` primitives + `BOX_SAVE_FAN`/`BOX_MODE_WAIT` envelope | `PrinterDetector::is_creality_k1() == false` |
 | K1, K1C, K1 Max (official CFS upgrade ≥ v2.3.5.33) | Creality K1 CFS upgrade firmware | Plain `BOX_*` primitives, no fan-save/mode-wait | `PrinterDetector::is_creality_k1() == true` |
-| K2 Plus on a community Kalico port | `Jacob10383/kalico` + a reimplemented `box.py` | High-level bare `T<n>` / `BOX_UNLOAD` | `fluidd_widget_version` in the box payload (the module's own identity marker) |
+| K2 Plus on a community Kalico port | `Jacob10383/kalico` + a reimplemented `box.py` | High-level bare `T<n>` / `BOX_UNLOAD` | `api_version == 1` in the box payload |
 
 **Axis 2 — box schema** (`CfsSchema`), detected per-payload by `AmsBackendCfs::detect_schema()`:
 
@@ -2065,7 +2065,7 @@ The `box` Klipper object is shared by several firmwares that agree on almost not
 
 Both axes are decided **from the payload, never from `PrinterDetector`** — a community port reports as stock K2 Plus hardware by every model signal, so model detection cannot see the firmware swap. `Stock` is the default for anything ambiguous.
 
-The dialect signal is deliberately *module identity* (`fluidd_widget_version`) rather than schema shape, so a future flat-schema firmware parses correctly without inheriting this one's command set. It also cannot be `has_macro("BOX_LOAD")`: the Fork commands are registered in Python, so they are not gcode_macros and never appear in `printer.objects.list`.
+The command dialect is selected by the explicit `api_version == 1` field rather than inferred from the `Flat` status layout, so another firmware can use the same layout without inheriting this one's commands. It also cannot be detected with `has_macro("BOX_LOAD")`: the Fork commands are registered in Python, so they are not gcode_macros and never appear in `printer.objects.list`.
 
 A `Flat` box whose module we cannot identify still has its control paths refused by `reject_if_flat_schema()`. Full field mapping, command signatures and remaining gaps: `printers/CREALITY_K2_SUPPORT.md` § "Community Kalico port".
 

--- a/docs/devel/printer-research/KLIPPER_FORKS_AND_PORTS.md
+++ b/docs/devel/printer-research/KLIPPER_FORKS_AND_PORTS.md
@@ -325,10 +325,9 @@ Consequences, in rough order of how much they cost us:
   port's filament system while refusing to drive it beats both extremes — and
   it is the correct state to sit in *while* you go find the module, rather than
   shipping a guessed command set.
-- Prefer a **module-identity marker** over a shape heuristic when deciding what
-  commands a firmware speaks. This module publishes its own widget-version
-  constant in its status object; keying on that keeps "what shape is the data"
-  and "what commands does it take" genuinely independent.
+- Prefer an **explicit API version** over inferring commands from the status
+  layout. This module publishes `api_version`; the `slots[]` structure selects
+  the parser, while the version selects the command dialect.
 
 **Footnote worth knowing:** this firmware ships **HelixScreen as its stock
 display**, pinned by version and SHA in its installer. Community ports are not

--- a/docs/devel/printers/CREALITY_K2_SUPPORT.md
+++ b/docs/devel/printers/CREALITY_K2_SUPPORT.md
@@ -374,7 +374,7 @@ Signatures below are read from the module's own `_register_commands` / `cmd_*` h
 | `BOX_LOAD` | `SLOT=<0..15>` | Low-level feed primitive. HelixScreen does not call it. |
 | `BOX_UNLOAD` | `[MANUAL=0\|1]` | **Rejects `SLOT`** outright: "BOX_UNLOAD no longer accepts SLOT". |
 | `T<n>` | `[FLUSH=0\|1]`, default 1 | Load/tool change. HelixScreen emits bare `T<n>`; the registered command owns the change engine (cut → retract → load → flush). |
-| `_BOX_SLOT_SET` | `SLOT=<n> MATERIAL=<str> COLOR="#RRGGBB" BRAND="..." NAME="..." SPOOLMAN_ID=<id\|-1>` | SLOT, MATERIAL, and COLOR are **required**. Helix always sends the optional fields; `-1` clears the Spoolman link. Material is uppercased by the module. |
+| `_BOX_SLOT_SET` | `SLOT=<n> MATERIAL="<str>" COLOR="#RRGGBB" BRAND="..." NAME="..." SPOOLMAN_ID=<id\|-1>` | SLOT, MATERIAL, and COLOR are **required**. The COLOR quotes are required because Kalico treats a bare `#` as a comment. Helix always sends the optional fields; `-1` clears the Spoolman link. Material is uppercased by the module. |
 | `_BOX_SLOT_CLEAR` | `SLOT=<n>` | Removes the persisted Box profile for the slot. |
 | `_BOX_MATERIAL_SET` | `MATERIAL=<str> TARGET_TEMP=<170..350>` | Edits the `materials` table. |
 | `_BOX_SET_RUNOUT_SWAP` | `ENABLE=0\|1` | Endless-spool equivalent. |
@@ -405,7 +405,7 @@ Remaining gaps, degraded rather than broken:
 | `set_tool_mapping` via TNN + `box.map` | No equivalent — the module maps tools to slots 1:1 |
 | Bypass / external spool load | The `external: true` entry is observable and `T<external>` exists, but the flow is untested here |
 
-Note `push_slot_color_to_firmware` is **not** a gap: its Fork counterpart is `_BOX_SLOT_SET`, which writes color, brand, name, and Spoolman link together. Because it requires a material, the backend reads the current slot profile to build the write; an empty material instead emits `_BOX_SLOT_CLEAR`. No temperature is sent to Box.
+Note `push_slot_color_to_firmware` is **not** a gap: its Fork counterpart is `_BOX_SLOT_SET`, which writes color, brand, name, and Spoolman link together. Because it requires a material, the backend reads the current slot profile to build the write. The explicit Clear Spool action emits `_BOX_SLOT_CLEAR`.
 
 Parse: `AmsBackendCfs::parse_flat_box_status()`. Builders: `load_gcode` / `unload_gcode` / `swap_gcode` / `slot_set_gcode`. Tests: `tests/unit/test_ams_cfs_flat_schema.cpp` (`[flat]`, `[fork]`), built on the real QJKZEMTS payload.
 
@@ -475,7 +475,7 @@ Because the heater target reads 0 while maintaining, HelixScreen synthesizes a c
 
 ### GCode Commands (from `box_wrapper.so` decompilation)
 
-These are the **stock K2** commands (`CfsMacroVariant::K2`). Two other dialects exist: the K1 official CFS upgrade's non-prefixed `BOX_*_MATERIAL` set (`CfsMacroVariant::K1`, see `CREALITY_K1_SUPPORT.md`), and the community Kalico port's high-level `BOX_LOAD` / `BOX_UNLOAD` / `BOX_CHANGE` set (`CfsMacroVariant::Fork`, see [Community Kalico port](#community-kalico-port)). Dialect and box schema vary **independently** — do not infer one from the other.
+These are the **stock K2** commands (`CfsMacroVariant::K2`). Two other dialects exist: the K1 official CFS upgrade's non-prefixed `BOX_*_MATERIAL` set (`CfsMacroVariant::K1`, see `CREALITY_K1_SUPPORT.md`), and the community Kalico port's high-level `T<n>` / `BOX_UNLOAD` set (`CfsMacroVariant::Fork`, see [Community Kalico port](#community-kalico-port)). Dialect and box schema vary **independently** — do not infer one from the other.
 
 #### Filament Operations
 | Command | Description |

--- a/docs/devel/printers/CREALITY_K2_SUPPORT.md
+++ b/docs/devel/printers/CREALITY_K2_SUPPORT.md
@@ -347,7 +347,7 @@ Top-level:
 | `materials` | dict | `{"PLA": {"target_temp": 220}, ...}` — per-material recommended temps, keyed by the same string each slot reports. Stock has no equivalent. |
 | `load_path` | object | Shared feed path: `encoder`, `buffer`, `printhead_sensor`, `clog_detection` |
 | `data_ready` / `driver_ready` | bool | Module readiness |
-| `fluidd_widget_version` | int | Marker for the port's own Fluidd widget |
+| `api_version` | int | Box command/status contract version; HelixScreen supports version 1 |
 
 Per-slot (`slots[i]`):
 
@@ -389,13 +389,13 @@ Signatures below are read from the module's own `_register_commands` / `cmd_*` h
 Two independent signals, both from the payload:
 
 - **Schema** → `detect_schema()`: a `T{n}` key means Stock; otherwise a `slots` array means Flat.
-- **Dialect** → `detect_fork_dialect()`: the presence of `fluidd_widget_version`, which is the module's own `WIDGET_VERSION` constant — a *module-identity* marker rather than a schema shape.
+- **Dialect** → `detect_fork_dialect()`: `api_version == 1` explicitly selects this Box command set; do not infer commands from the `slots[]` layout.
 
-The dialect signal deliberately is not `has_macro("BOX_LOAD")`: these commands are registered in Python via `gcode.register_command`, so they are **not** gcode_macros and never appear in `printer.objects.list`. A flat payload *without* the marker parses fine but keeps the stock dialect and stays gated — a different flat-schema firmware must not inherit this one's command set.
+The dialect signal deliberately is not `has_macro("BOX_LOAD")`: these commands are registered in Python via `gcode.register_command`, so they are **not** gcode_macros and never appear in `printer.objects.list`. A flat payload *without* a supported `api_version` parses fine but keeps the stock dialect and stays gated — a different flat-schema firmware must not inherit this one's command set.
 
 #### Current support status
 
-**Full read and control.** Slot display, materials, colors, environment and path sensors parse; load / unload / tool-change / slot-metadata writes all emit verified commands. `reject_if_flat_schema()` now gates only a flat box whose module we cannot identify.
+**Fork command paths enabled.** Slot display, materials, colors, environment and path sensors parse; load / unload / tool-change / slot-metadata writes all emit verified commands. `reject_if_flat_schema()` gates only a flat box whose API version we cannot identify.
 
 Remaining gaps, degraded rather than broken:
 
@@ -663,7 +663,7 @@ Note that `chamber_temp` is **not** universal on K2 hardware either: the Kalico 
 ### CFS
 - **Closed-source protocol** — CFS communication relies on `box_wrapper.cpython-39.so` binary blob. Protocol has been reverse-engineered from strings but full reimplementation is not yet available.
 - **Material database is cloud-fetched** — The material database at `/mnt/UDISK/creality/userdata/box/material_database.json` is downloaded from Creality's cloud. HelixScreen should include a fallback mapping for common material type codes.
-- **Community Kalico ports are read-only** — a port with a reimplemented `box.py` publishes the flat schema and a third macro dialect. Slots display; load/unload/tool-change are refused pending a verified command signature. See [Community Kalico port](#community-kalico-port).
+- **Community Kalico ports require Box API v1 for control** — the flat status layout still parses without it, but load/unload/tool-change stay gated until `api_version == 1` identifies the supported command dialect. See [Community Kalico port](#community-kalico-port).
 
 ### Platform
 - **Low CPU** — Dual Cortex-A7 at ~57 BogoMIPS. Performance-sensitive features (bed mesh 3D, animations) may need throttling.

--- a/docs/devel/printers/CREALITY_K2_SUPPORT.md
+++ b/docs/devel/printers/CREALITY_K2_SUPPORT.md
@@ -371,10 +371,11 @@ Signatures below are read from the module's own `_register_commands` / `cmd_*` h
 
 | Command | Signature | Notes |
 |---------|-----------|-------|
-| `BOX_LOAD` | `SLOT=<0..15>` | **Fresh load only.** Raises "T*n* is already loaded; unload it before loading T*m*" if another bay is seated — a swap must use `T<n>`. |
+| `BOX_LOAD` | `SLOT=<0..15>` | Low-level feed primitive. HelixScreen does not call it. |
 | `BOX_UNLOAD` | `[MANUAL=0\|1]` | **Rejects `SLOT`** outright: "BOX_UNLOAD no longer accepts SLOT". |
-| `T<n>` | `[FLUSH=0\|1]`, default 1 | Tool change. Registered per physical slot + the external bay by `_register_t_commands`; routes through the change engine (cut → retract → load → flush). |
-| `_BOX_SLOT_SET` | `SLOT=<n> MATERIAL=<str> COLOR=#RRGGBB [BRAND=] [NAME=] [SPOOLMAN_ID=]` | All three of SLOT/MATERIAL/COLOR **required**. Material is uppercased by the module. |
+| `T<n>` | `[FLUSH=0\|1]`, default 1 | Load/tool change. HelixScreen emits bare `T<n>`; the registered command owns the change engine (cut → retract → load → flush). |
+| `_BOX_SLOT_SET` | `SLOT=<n> MATERIAL=<str> COLOR="#RRGGBB" BRAND="..." NAME="..." SPOOLMAN_ID=<id\|-1>` | SLOT, MATERIAL, and COLOR are **required**. Helix always sends the optional fields; `-1` clears the Spoolman link. Material is uppercased by the module. |
+| `_BOX_SLOT_CLEAR` | `SLOT=<n>` | Removes the persisted Box profile for the slot. |
 | `_BOX_MATERIAL_SET` | `MATERIAL=<str> TARGET_TEMP=<170..350>` | Edits the `materials` table. |
 | `_BOX_SET_RUNOUT_SWAP` | `ENABLE=0\|1` | Endless-spool equivalent. |
 | `BOX_CUT`, `NOZZLE_CLEAN`, `BOX_GO_TO_WASTEBIN`, `BOX_RUNOUT_CHECK`, `BOX_DEBUG`, `BOX_BUFFER_RETRACT` | no parameters | |
@@ -404,7 +405,7 @@ Remaining gaps, degraded rather than broken:
 | `set_tool_mapping` via TNN + `box.map` | No equivalent — the module maps tools to slots 1:1 |
 | Bypass / external spool load | The `external: true` entry is observable and `T<external>` exists, but the flow is untested here |
 
-Note `push_slot_color_to_firmware` is **not** a gap: its Fork counterpart is `_BOX_SLOT_SET`. Because that command requires a material alongside the color, the backend reads the slot's current material to build the write, and skips only when the slot has none.
+Note `push_slot_color_to_firmware` is **not** a gap: its Fork counterpart is `_BOX_SLOT_SET`, which writes color, brand, name, and Spoolman link together. Because it requires a material, the backend reads the current slot profile to build the write; an empty material instead emits `_BOX_SLOT_CLEAR`. No temperature is sent to Box.
 
 Parse: `AmsBackendCfs::parse_flat_box_status()`. Builders: `load_gcode` / `unload_gcode` / `swap_gcode` / `slot_set_gcode`. Tests: `tests/unit/test_ams_cfs_flat_schema.cpp` (`[flat]`, `[fork]`), built on the real QJKZEMTS payload.
 

--- a/include/ams_backend_cfs.h
+++ b/include/ams_backend_cfs.h
@@ -81,20 +81,11 @@ class CfsErrorDecoder {
 /// K1-series printer. Issue #968.
 ///
 /// Fork — community Kalico ports of the K2 whose reimplemented `box` module
-/// replaces Creality's closed one. High-level and self-contained: BOX_LOAD,
-/// BOX_UNLOAD, BOX_CHANGE, BOX_CUT, BOX_RESET, BOX_RESUME, BOX_RECOVERY,
-/// BOX_GO_TO_WASTEBIN, BOX_EMERGENCY_STOP — the port's box.py owns the whole
-/// feed/purge/park sequence, so there is no envelope for HelixScreen to
-/// assemble. `BOX_LOAD` in the macro list is the discriminator; neither stock
-/// dialect defines it.
-///
-/// RESERVED — nothing assigns this value yet. The port's box.py is unpublished,
-/// so BOX_LOAD's parameter name is unverified and no builder emits it; the
-/// control paths are refused up front by reject_if_flat_schema() instead. The
-/// value exists so the dialect axis is expressible independently of CfsSchema,
-/// which is the mistake that made this firmware hard to support in the first
-/// place. See docs/devel/printers/CREALITY_K2_SUPPORT.md § "Community Kalico
-/// port".
+/// replaces Creality's closed one. `T<n>` and `BOX_UNLOAD` are high-level and
+/// self-contained: box.py owns the whole feed/purge/park sequence, so
+/// HelixScreen sends no stock envelope. Detected by `fluidd_widget_version` in
+/// the box payload. See docs/devel/printers/CREALITY_K2_SUPPORT.md §
+/// "Community Kalico port".
 enum class CfsMacroVariant {
     K2,
     K1,
@@ -269,7 +260,8 @@ class AmsBackendCfs : public AmsSubscriptionBackend {
     [[nodiscard]] static bool detect_fork_dialect(const nlohmann::json& box_json);
 
     /// `_BOX_SLOT_SET` — the Fork counterpart to the stock BOX_MODIFY_TN_DATA
-    /// color write. Returns "" when the module would reject the command.
+    /// color write. Returns "" when the module would reject the command; an
+    /// empty material is handled by `_BOX_SLOT_CLEAR` before this builder.
     ///
     /// SLOT, MATERIAL and COLOR are all required by box.py's cmd_slot_set, so
     /// unlike the stock path this cannot be a color-only write; the caller must
@@ -277,7 +269,8 @@ class AmsBackendCfs : public AmsSubscriptionBackend {
     /// module's own `str(material).strip().upper()` normalization, so a later
     /// status frame echoes back exactly what we sent.
     static std::string slot_set_gcode(int global_slot_index, const std::string& material,
-                                      uint32_t color_rgb);
+                                      uint32_t color_rgb, const std::string& brand,
+                                      const std::string& name, int spoolman_id);
 
     // GCode helpers (public for testing)
     static std::string load_gcode(int global_slot_index,

--- a/include/ams_backend_cfs.h
+++ b/include/ams_backend_cfs.h
@@ -186,9 +186,11 @@ class AmsBackendCfs : public AmsSubscriptionBackend {
     // override_store_->clear_async. CFS firmware populates brand / color_name /
     // total_weight_g from its RFID material database, so those fields are
     // preserved. Only spool_name / spoolman_* / remaining_weight_g are zeroed.
-    // The hardware-event detector calls this internally once an RFID
-    // fingerprint change confirms a physical swap.
     void clear_slot_override(int slot_index) override;
+
+    // Explicit Clear Spool action. Fork firmware owns the persisted profile;
+    // stock CFS dialects have no equivalent command.
+    void clear_box_slot_profile(int slot_index);
 
     // Bypass (not supported)
     AmsError enable_bypass() override;
@@ -260,8 +262,7 @@ class AmsBackendCfs : public AmsSubscriptionBackend {
     [[nodiscard]] static bool detect_fork_dialect(const nlohmann::json& box_json);
 
     /// `_BOX_SLOT_SET` — the Fork counterpart to the stock BOX_MODIFY_TN_DATA
-    /// color write. Returns "" when the module would reject the command; an
-    /// empty material is handled by `_BOX_SLOT_CLEAR` before this builder.
+    /// color write. Returns "" when the module would reject the command.
     ///
     /// SLOT, MATERIAL and COLOR are all required by box.py's cmd_slot_set, so
     /// unlike the stock path this cannot be a color-only write; the caller must

--- a/include/ams_backend_cfs.h
+++ b/include/ams_backend_cfs.h
@@ -83,8 +83,8 @@ class CfsErrorDecoder {
 /// Fork — community Kalico ports of the K2 whose reimplemented `box` module
 /// replaces Creality's closed one. `T<n>` and `BOX_UNLOAD` are high-level and
 /// self-contained: box.py owns the whole feed/purge/park sequence, so
-/// HelixScreen sends no stock envelope. Detected by `fluidd_widget_version` in
-/// the box payload. See docs/devel/printers/CREALITY_K2_SUPPORT.md §
+/// HelixScreen sends no stock envelope. Detected by `api_version` in the box
+/// payload. See docs/devel/printers/CREALITY_K2_SUPPORT.md §
 /// "Community Kalico port".
 enum class CfsMacroVariant {
     K2,
@@ -251,14 +251,10 @@ class AmsBackendCfs : public AmsSubscriptionBackend {
     /// True when this `box` payload comes from the community box.py, i.e. the
     /// firmware speaks CfsMacroVariant::Fork.
     ///
-    /// Keys on `fluidd_widget_version`, which is that module's own
-    /// WIDGET_VERSION constant — a MODULE-identity marker, not a schema shape.
-    /// That distinction matters twice over: it keeps the dialect axis separate
-    /// from CfsSchema (a different flat-schema firmware must not inherit this
-    /// one's command set), and it is the only signal available. The Fork
-    /// commands are registered in Python via gcode.register_command, so they
-    /// are NOT gcode_macros and never appear in printer.objects.list —
-    /// PrinterDiscovery::has_macro("BOX_LOAD") can never see them.
+    /// Requires `api_version == 1`, the explicit version for this command
+    /// dialect. Do not infer commands from the `slots[]` status layout alone;
+    /// another firmware may expose the same flat layout. The Fork commands are
+    /// registered in Python, so PrinterDiscovery::has_macro() cannot see them.
     [[nodiscard]] static bool detect_fork_dialect(const nlohmann::json& box_json);
 
     /// `_BOX_SLOT_SET` — the Fork counterpart to the stock BOX_MODIFY_TN_DATA
@@ -331,17 +327,13 @@ class AmsBackendCfs : public AmsSubscriptionBackend {
     /// affected printers report as stock K2 hardware, so it is only knowable
     /// from a payload. Stock until a payload says otherwise.
     ///
-    /// Also the guard on the control paths. A Flat box means the firmware's
-    /// box module is a community reimplementation whose command surface we have
-    /// not verified; emitting the stock CR_BOX_*/BOX_* sequences at it sends
-    /// commands it does not define (confirmed on bundle QJKZEMTS: zero
-    /// CR_BOX_*, zero BOX_MODIFY_TN_DATA, zero M8200 in its config). Refusing
-    /// with a clear error beats a half-executed feed sequence.
+    /// Payload layout only. The command dialect is selected independently;
+    /// Flat + Fork is supported, while an unidentified Flat implementation is
+    /// kept off stock command paths.
     CfsSchema schema_ = CfsSchema::Stock;
 
-    /// SUCCESS on stock firmware; a not_supported error naming @p operation
-    /// when the box is a flat-schema reimplementation. Called at the top of
-    /// every path that emits a stock gcode sequence.
+    /// SUCCESS for stock schemas and the identified Fork dialect; returns
+    /// not_supported for an unidentified Flat implementation.
     [[nodiscard]] AmsError reject_if_flat_schema(const char* operation) const;
 
     // Callback lifetime management

--- a/src/printer/ams_backend_cfs.cpp
+++ b/src/printer/ams_backend_cfs.cpp
@@ -136,6 +136,23 @@ bool is_material_code_sentinel(const std::string& v) {
     return v.empty() || v == "none" || v == "None" || v == "-1" || v == "unknown";
 }
 
+std::string quote_gcode_param(const std::string& value) {
+    std::string quoted;
+    quoted.reserve(value.size() + 2);
+    quoted += '"';
+    for (char c : value) {
+        if (c == '\n' || c == '\r') {
+            quoted += ' ';
+        } else {
+            if (c == '\\' || c == '"')
+                quoted += '\\';
+            quoted += c;
+        }
+    }
+    quoted += '"';
+    return quoted;
+}
+
 } // namespace
 
 struct CfsErrorEntry {
@@ -1718,27 +1735,35 @@ void AmsBackendCfs::push_slot_color_to_firmware(int global_index, uint32_t color
         return;
     }
 
-    // The Fork module defines no BOX_MODIFY_TN_DATA; its equivalent is
-    // _BOX_SLOT_SET, which writes the whole slot profile at once and REQUIRES a
-    // material alongside the color. Read the slot's current material to satisfy
-    // that — a slot with no material yet yields no command, and the local
-    // override still holds the user's color either way.
+    // The Fork module defines no BOX_MODIFY_TN_DATA. `_BOX_SLOT_SET` requires
+    // a material; an empty material selects Box's separate `_BOX_SLOT_CLEAR`.
     if (macro_variant_ == CfsMacroVariant::Fork) {
         std::string material;
+        std::string brand;
+        std::string name;
+        int spoolman_id = 0;
         {
             std::lock_guard<std::mutex> lock(mutex_);
             for (const auto& unit : system_info_.units) {
                 for (const auto& slot : unit.slots) {
                     if (slot.global_index == global_index) {
                         material = slot.material;
+                        brand = slot.brand;
+                        name = slot.spool_name;
+                        spoolman_id = slot.spoolman_id;
+                        break;
                     }
                 }
             }
         }
-        std::string gcode = slot_set_gcode(global_index, material, color_rgb);
+        if (material.empty()) {
+            execute_gcode("_BOX_SLOT_CLEAR SLOT=" + std::to_string(global_index));
+            return;
+        }
+        std::string gcode =
+            slot_set_gcode(global_index, material, color_rgb, brand, name, spoolman_id);
         if (gcode.empty()) {
-            spdlog::debug("{} slot-set skipped for slot {} (no material) — local override only",
-                          backend_log_tag(), global_index);
+            spdlog::debug("{} slot-set skipped for slot {}", backend_log_tag(), global_index);
             return;
         }
         execute_gcode(gcode);
@@ -1967,7 +1992,8 @@ bool AmsBackendCfs::detect_fork_dialect(const nlohmann::json& box_json) {
 }
 
 std::string AmsBackendCfs::slot_set_gcode(int global_slot_index, const std::string& material,
-                                          uint32_t color_rgb) {
+                                          uint32_t color_rgb, const std::string& brand,
+                                          const std::string& name, int spoolman_id) {
     constexpr int kCfsMaxSlots = 16; // 4 units × 4 slots
     if (global_slot_index < 0 || global_slot_index >= kCfsMaxSlots) {
         spdlog::error("[AMS CFS] Invalid slot index for slot-set: {}", global_slot_index);
@@ -1984,27 +2010,23 @@ std::string AmsBackendCfs::slot_set_gcode(int global_slot_index, const std::stri
     for (char& c : upper) {
         c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
     }
-    // snprintf to match the stock BOX_MODIFY_TN_DATA builder below, which uses
-    // the same idiom for the same reason: a fixed-shape gcode line.
-    char gcode[160];
-    std::snprintf(gcode, sizeof(gcode), "_BOX_SLOT_SET SLOT=%d MATERIAL=%s COLOR=#%06X",
-                  global_slot_index, upper.c_str(), color_rgb & 0xFFFFFFu);
-    return gcode;
+    char color[10];
+    std::snprintf(color, sizeof(color), "#%06X", color_rgb & 0xFFFFFFu);
+    return "_BOX_SLOT_SET SLOT=" + std::to_string(global_slot_index) + " MATERIAL=" + upper +
+           " COLOR=" + quote_gcode_param(color) + " BRAND=" + quote_gcode_param(brand) +
+           " NAME=" + quote_gcode_param(name) +
+           " SPOOLMAN_ID=" + std::to_string(spoolman_id > 0 ? spoolman_id : -1);
 }
 
 std::string AmsBackendCfs::load_gcode(int idx, CfsMacroVariant variant) {
     if (variant == CfsMacroVariant::Fork) {
-        // BOX_LOAD SLOT=<n>. The module owns the entire feed sequence — park,
-        // purge, prime and clean all happen inside it — so there is no envelope
-        // to assemble. It is a FRESH load only: box.py raises "T%d is already
-        // loaded; unload it before loading T%d" when another bay is seated,
-        // which is why a swap routes to T<n> instead.
+        // The Box T command owns the complete load or change operation.
         constexpr int kCfsMaxSlots = 16;
         if (idx < 0 || idx >= kCfsMaxSlots) {
             spdlog::error("[AMS CFS] Invalid slot index for load: {}", idx);
             return "";
         }
-        return "BOX_LOAD SLOT=" + std::to_string(idx);
+        return "T" + std::to_string(idx);
     }
     std::string tnn = CfsMaterialDb::slot_to_tnn(idx);
     if (tnn.empty()) {
@@ -2078,14 +2100,12 @@ std::string AmsBackendCfs::swap_gcode(int idx, CfsMacroVariant variant) {
         // BOX_CHANGE; that name appears only in a user-written alias macro that
         // this firmware does not define.
         //
-        // FLUSH=1 is the module's own default and keeps slicer flush volumes
-        // honored; spelled explicitly so the intent survives a default change.
         constexpr int kCfsMaxSlots = 16;
         if (idx < 0 || idx >= kCfsMaxSlots) {
             spdlog::error("[AMS CFS] Invalid slot index for swap: {}", idx);
             return "";
         }
-        return "T" + std::to_string(idx) + " FLUSH=1";
+        return "T" + std::to_string(idx);
     }
     std::string tnn = CfsMaterialDb::slot_to_tnn(idx);
     if (tnn.empty()) {
@@ -2165,17 +2185,25 @@ AmsError AmsBackendCfs::dispatch_action_script(std::string gcode) {
                 // envelope ran BOX_SAVE_FAN). The K1 official CFS upgrade
                 // firmware lacks the macro and never saved fan state, so emitting
                 // it there just returns key61 — skip it on K1. (#968)
-                if (macro_variant_ != CfsMacroVariant::K1) {
+                if (macro_variant_ == CfsMacroVariant::K2) {
                     api_->execute_gcode(
                         "BOX_RESTORE_FAN", []() {}, [](const MoonrakerError&) {},
                         MoonrakerAPI::AMS_OPERATION_TIMEOUT_MS);
                 }
-                api_->execute_gcode(
-                    "RESTORE_GCODE_STATE NAME=helix_cfs_load", []() {},
-                    [](const MoonrakerError&) {}, MoonrakerAPI::AMS_OPERATION_TIMEOUT_MS);
+                if (macro_variant_ != CfsMacroVariant::Fork) {
+                    api_->execute_gcode(
+                        "RESTORE_GCODE_STATE NAME=helix_cfs_load", []() {},
+                        [](const MoonrakerError&) {}, MoonrakerAPI::AMS_OPERATION_TIMEOUT_MS);
+                }
             }
         });
     };
+
+    if (macro_variant_ == CfsMacroVariant::Fork) {
+        api_->execute_gcode(gcode, std::move(on_complete), std::move(on_error),
+                            MoonrakerAPI::AMS_OPERATION_TIMEOUT_MS);
+        return AmsErrorHelper::success();
+    }
 
     // Homing-then-execute — same pattern as ensure_homed_then but with our
     // own completion callbacks that propagate to action-state cleanup.

--- a/src/printer/ams_backend_cfs.cpp
+++ b/src/printer/ams_backend_cfs.cpp
@@ -1736,7 +1736,7 @@ void AmsBackendCfs::push_slot_color_to_firmware(int global_index, uint32_t color
     }
 
     // The Fork module defines no BOX_MODIFY_TN_DATA. `_BOX_SLOT_SET` requires
-    // a material; an empty material selects Box's separate `_BOX_SLOT_CLEAR`.
+    // a material; explicit clears route through clear_box_slot_profile().
     if (macro_variant_ == CfsMacroVariant::Fork) {
         std::string material;
         std::string brand;
@@ -1755,10 +1755,6 @@ void AmsBackendCfs::push_slot_color_to_firmware(int global_index, uint32_t color
                     }
                 }
             }
-        }
-        if (material.empty()) {
-            execute_gcode("_BOX_SLOT_CLEAR SLOT=" + std::to_string(global_index));
-            return;
         }
         std::string gcode =
             slot_set_gcode(global_index, material, color_rgb, brand, name, spoolman_id);
@@ -2012,7 +2008,8 @@ std::string AmsBackendCfs::slot_set_gcode(int global_slot_index, const std::stri
     }
     char color[10];
     std::snprintf(color, sizeof(color), "#%06X", color_rgb & 0xFFFFFFu);
-    return "_BOX_SLOT_SET SLOT=" + std::to_string(global_slot_index) + " MATERIAL=" + upper +
+    return "_BOX_SLOT_SET SLOT=" + std::to_string(global_slot_index) +
+           " MATERIAL=" + quote_gcode_param(upper) +
            " COLOR=" + quote_gcode_param(color) + " BRAND=" + quote_gcode_param(brand) +
            " NAME=" + quote_gcode_param(name) +
            " SPOOLMAN_ID=" + std::to_string(spoolman_id > 0 ? spoolman_id : -1);
@@ -2703,6 +2700,12 @@ void AmsBackendCfs::clear_slot_override(int slot_index) {
     }
 
     emit_event(EVENT_SLOT_CHANGED, std::to_string(slot_index));
+}
+
+void AmsBackendCfs::clear_box_slot_profile(int slot_index) {
+    if (macro_variant_ == CfsMacroVariant::Fork) {
+        execute_gcode("_BOX_SLOT_CLEAR SLOT=" + std::to_string(slot_index));
+    }
 }
 
 } // namespace helix::printer

--- a/src/printer/ams_backend_cfs.cpp
+++ b/src/printer/ams_backend_cfs.cpp
@@ -1165,18 +1165,15 @@ void AmsBackendCfs::handle_status_update(const nlohmann::json& notification) {
 
         if (is_flat && schema_ != CfsSchema::Flat) {
             schema_ = CfsSchema::Flat;
-            // Dialect is latched from the same payload but on a SEPARATE
-            // signal — the module's own identity marker, not the schema shape
-            // (see detect_fork_dialect). A flat payload without that marker
-            // keeps the stock dialect and stays gated, because we would have no
-            // verified command set for it.
+            // Select the command dialect from the explicit API version, not by
+            // assuming every `slots[]` payload implements the same commands.
             if (detect_fork_dialect(box)) {
                 macro_variant_ = CfsMacroVariant::Fork;
                 spdlog::info("[AMS CFS] Flat box schema + fork dialect detected "
-                             "(community box.py, widget v{}) — full control enabled",
-                             helix::json_util::safe_int(box, "fluidd_widget_version", 0));
+                             "(community box.py, API v{}) — Fork control enabled",
+                             helix::json_util::safe_int(box, "api_version", 0));
             } else {
-                spdlog::warn("[AMS CFS] Flat box schema without a known module marker — "
+                spdlog::warn("[AMS CFS] Flat box schema without a supported API version — "
                              "slot display active, control paths disabled (no verified "
                              "command dialect)");
             }
@@ -1984,7 +1981,7 @@ std::string wrap_with_park(CfsMacroVariant variant, const std::string& body, boo
 } // namespace
 
 bool AmsBackendCfs::detect_fork_dialect(const nlohmann::json& box_json) {
-    return box_json.is_object() && box_json.contains("fluidd_widget_version");
+    return box_json.is_object() && helix::json_util::safe_int(box_json, "api_version", 0) == 1;
 }
 
 std::string AmsBackendCfs::slot_set_gcode(int global_slot_index, const std::string& material,

--- a/src/ui/ui_panel_ams.cpp
+++ b/src/ui/ui_panel_ams.cpp
@@ -26,6 +26,9 @@
 #include "ui_utils.h"
 
 #include "ams_backend.h"
+#if HELIX_HAS_CFS
+#include "ams_backend_cfs.h"
+#endif
 #include "ams_state.h"
 #include "ams_types.h"
 #include "app_globals.h"
@@ -1555,6 +1558,12 @@ void AmsPanel::show_context_menu(int slot_index, lv_obj_t* near_widget, lv_point
                 cleared.total_weight_g = -1;
                 auto error = backend->set_slot_info(slot, cleared);
                 if (error.success()) {
+#if HELIX_HAS_CFS
+                    if (backend->get_type() == AmsType::CFS) {
+                        static_cast<helix::printer::AmsBackendCfs*>(backend)
+                            ->clear_box_slot_profile(slot);
+                    }
+#endif
                     AmsState::instance().sync_from_backend();
                     NOTIFY_INFO(lv_tr("Slot {} spool cleared"), slot + 1);
                 } else {

--- a/tests/unit/test_ams_backend_cfs.cpp
+++ b/tests/unit/test_ams_backend_cfs.cpp
@@ -86,6 +86,9 @@ class CfsTestAccess {
     static void set_macro_variant_k1(AmsBackendCfs& b) {
         b.macro_variant_ = helix::printer::CfsMacroVariant::K1;
     }
+    static void set_macro_variant_fork(AmsBackendCfs& b) {
+        b.macro_variant_ = helix::printer::CfsMacroVariant::Fork;
+    }
     // Seed N connected CFS units (unit_index 0..N-1) so device-action code that
     // iterates system_info_.units (e.g. refresh_rfid → BOX_INFO_REFRESH) has
     // addressable units without a live Moonraker parse.
@@ -168,6 +171,19 @@ class CfsK1RemapHelper : public CfsRemapHelper {
     }
 };
 } // namespace
+
+TEST_CASE("CFS Box profile clear is Fork-only", "[ams][cfs][fork]") {
+    CfsRemapHelper backend;
+
+    backend.clear_box_slot_profile(2);
+    REQUIRE(backend.captured.empty());
+
+    CfsTestAccess::set_macro_variant_fork(backend);
+
+    backend.clear_box_slot_profile(2);
+
+    REQUIRE(backend.captured == std::vector<std::string>{"_BOX_SLOT_CLEAR SLOT=2"});
+}
 
 TEST_CASE("CFS type enum", "[ams][cfs]") {
     SECTION("CFS is a valid AmsType") {

--- a/tests/unit/test_ams_cfs_flat_schema.cpp
+++ b/tests/unit/test_ams_cfs_flat_schema.cpp
@@ -467,27 +467,33 @@ TEST_CASE("CFS Fork dialect: detected from the module's own identity marker",
 // --- Fork slot metadata write ----------------------------------------------
 
 TEST_CASE("CFS Fork dialect: slot metadata write", "[ams][cfs][flat][fork]") {
-    // _BOX_SLOT_SET SLOT=<n> MATERIAL=<str> COLOR="#RRGGBB" BRAND="..." NAME="..."
+    // _BOX_SLOT_SET SLOT=<n> MATERIAL="<str>" COLOR="#RRGGBB" BRAND="..." NAME="..."
     // All three of SLOT/MATERIAL/COLOR are REQUIRED — box.py raises on any
     // missing one, so a color-only write (the stock BOX_MODIFY_TN_DATA shape)
     // is not expressible and must carry the material along.
     SECTION("emits the full Box profile with quoted values") {
         const std::string g =
             AmsBackendCfs::slot_set_gcode(2, "PETG", 0x0A2989, "eSUN", "Ocean Blue", 42);
-        REQUIRE(g == "_BOX_SLOT_SET SLOT=2 MATERIAL=PETG COLOR=\"#0A2989\" BRAND=\"eSUN\" "
+        REQUIRE(g == "_BOX_SLOT_SET SLOT=2 MATERIAL=\"PETG\" COLOR=\"#0A2989\" BRAND=\"eSUN\" "
                      "NAME=\"Ocean Blue\" SPOOLMAN_ID=42");
     }
 
     SECTION("clears optional Box profile fields") {
         REQUIRE(AmsBackendCfs::slot_set_gcode(0, "PLA", 0x000000, "", "", 0) ==
-                "_BOX_SLOT_SET SLOT=0 MATERIAL=PLA COLOR=\"#000000\" BRAND=\"\" NAME=\"\" "
+                "_BOX_SLOT_SET SLOT=0 MATERIAL=\"PLA\" COLOR=\"#000000\" BRAND=\"\" NAME=\"\" "
                 "SPOOLMAN_ID=-1");
     }
 
     SECTION("escapes quoted profile fields") {
         REQUIRE(AmsBackendCfs::slot_set_gcode(0, "petg", 0xFFFFFF, "A\\B", "Bob \"Blue\"", 7) ==
-                "_BOX_SLOT_SET SLOT=0 MATERIAL=PETG COLOR=\"#FFFFFF\" BRAND=\"A\\\\B\" "
+                "_BOX_SLOT_SET SLOT=0 MATERIAL=\"PETG\" COLOR=\"#FFFFFF\" BRAND=\"A\\\\B\" "
                 "NAME=\"Bob \\\"Blue\\\"\" SPOOLMAN_ID=7");
+    }
+
+    SECTION("quotes free-text material names") {
+        REQUIRE(AmsBackendCfs::slot_set_gcode(0, "PLA Matte", 0xFFFFFF, "", "", 0) ==
+                "_BOX_SLOT_SET SLOT=0 MATERIAL=\"PLA MATTE\" COLOR=\"#FFFFFF\" BRAND=\"\" "
+                "NAME=\"\" SPOOLMAN_ID=-1");
     }
 
     SECTION("no command without a material — the module would reject it") {

--- a/tests/unit/test_ams_cfs_flat_schema.cpp
+++ b/tests/unit/test_ams_cfs_flat_schema.cpp
@@ -385,10 +385,10 @@ TEST_CASE("CFS flat schema: malformed payloads degrade, never throw", "[ams][cfs
 // so none of these carry the stock envelope.
 
 TEST_CASE("CFS Fork dialect: gcode builders", "[ams][cfs][flat][fork]") {
-    SECTION("load emits BOX_LOAD with a SLOT parameter") {
-        REQUIRE(AmsBackendCfs::load_gcode(0, CfsMacroVariant::Fork) == "BOX_LOAD SLOT=0");
-        REQUIRE(AmsBackendCfs::load_gcode(7, CfsMacroVariant::Fork) == "BOX_LOAD SLOT=7");
-        REQUIRE(AmsBackendCfs::load_gcode(15, CfsMacroVariant::Fork) == "BOX_LOAD SLOT=15");
+    SECTION("load emits the Box-owned T command") {
+        REQUIRE(AmsBackendCfs::load_gcode(0, CfsMacroVariant::Fork) == "T0");
+        REQUIRE(AmsBackendCfs::load_gcode(7, CfsMacroVariant::Fork) == "T7");
+        REQUIRE(AmsBackendCfs::load_gcode(15, CfsMacroVariant::Fork) == "T15");
     }
 
     SECTION("unload emits a bare BOX_UNLOAD — never with SLOT") {
@@ -400,8 +400,8 @@ TEST_CASE("CFS Fork dialect: gcode builders", "[ams][cfs][flat][fork]") {
     }
 
     SECTION("swap emits the T<n> toolchange, not BOX_CHANGE") {
-        REQUIRE(AmsBackendCfs::swap_gcode(0, CfsMacroVariant::Fork) == "T0 FLUSH=1");
-        REQUIRE(AmsBackendCfs::swap_gcode(3, CfsMacroVariant::Fork) == "T3 FLUSH=1");
+        REQUIRE(AmsBackendCfs::swap_gcode(0, CfsMacroVariant::Fork) == "T0");
+        REQUIRE(AmsBackendCfs::swap_gcode(3, CfsMacroVariant::Fork) == "T3");
         REQUIRE(AmsBackendCfs::swap_gcode(3, CfsMacroVariant::Fork).find("BOX_CHANGE") ==
                 std::string::npos);
     }
@@ -467,34 +467,36 @@ TEST_CASE("CFS Fork dialect: detected from the module's own identity marker",
 // --- Fork slot metadata write ----------------------------------------------
 
 TEST_CASE("CFS Fork dialect: slot metadata write", "[ams][cfs][flat][fork]") {
-    // _BOX_SLOT_SET SLOT=<n> MATERIAL=<str> COLOR=#RRGGBB [BRAND=] [NAME=]
+    // _BOX_SLOT_SET SLOT=<n> MATERIAL=<str> COLOR="#RRGGBB" BRAND="..." NAME="..."
     // All three of SLOT/MATERIAL/COLOR are REQUIRED — box.py raises on any
     // missing one, so a color-only write (the stock BOX_MODIFY_TN_DATA shape)
     // is not expressible and must carry the material along.
-    SECTION("emits all three required parameters") {
-        const std::string g = AmsBackendCfs::slot_set_gcode(2, "PETG", 0x0A2989);
-        REQUIRE(g == "_BOX_SLOT_SET SLOT=2 MATERIAL=PETG COLOR=#0A2989");
+    SECTION("emits the full Box profile with quoted values") {
+        const std::string g =
+            AmsBackendCfs::slot_set_gcode(2, "PETG", 0x0A2989, "eSUN", "Ocean Blue", 42);
+        REQUIRE(g == "_BOX_SLOT_SET SLOT=2 MATERIAL=PETG COLOR=\"#0A2989\" BRAND=\"eSUN\" "
+                     "NAME=\"Ocean Blue\" SPOOLMAN_ID=42");
     }
 
-    SECTION("color is zero-padded to six hex digits") {
-        REQUIRE(AmsBackendCfs::slot_set_gcode(0, "PLA", 0x000000) ==
-                "_BOX_SLOT_SET SLOT=0 MATERIAL=PLA COLOR=#000000");
-        REQUIRE(AmsBackendCfs::slot_set_gcode(1, "ABS", 0x0000FF) ==
-                "_BOX_SLOT_SET SLOT=1 MATERIAL=ABS COLOR=#0000FF");
+    SECTION("clears optional Box profile fields") {
+        REQUIRE(AmsBackendCfs::slot_set_gcode(0, "PLA", 0x000000, "", "", 0) ==
+                "_BOX_SLOT_SET SLOT=0 MATERIAL=PLA COLOR=\"#000000\" BRAND=\"\" NAME=\"\" "
+                "SPOOLMAN_ID=-1");
     }
 
-    SECTION("material is uppercased to match the module's own normalization") {
-        REQUIRE(AmsBackendCfs::slot_set_gcode(0, "petg", 0xFFFFFF) ==
-                "_BOX_SLOT_SET SLOT=0 MATERIAL=PETG COLOR=#FFFFFF");
+    SECTION("escapes quoted profile fields") {
+        REQUIRE(AmsBackendCfs::slot_set_gcode(0, "petg", 0xFFFFFF, "A\\B", "Bob \"Blue\"", 7) ==
+                "_BOX_SLOT_SET SLOT=0 MATERIAL=PETG COLOR=\"#FFFFFF\" BRAND=\"A\\\\B\" "
+                "NAME=\"Bob \\\"Blue\\\"\" SPOOLMAN_ID=7");
     }
 
     SECTION("no command without a material — the module would reject it") {
-        REQUIRE(AmsBackendCfs::slot_set_gcode(0, "", 0xFFFFFF).empty());
+        REQUIRE(AmsBackendCfs::slot_set_gcode(0, "", 0xFFFFFF, "", "", 0).empty());
     }
 
     SECTION("out-of-range slot yields no command") {
-        REQUIRE(AmsBackendCfs::slot_set_gcode(-1, "PLA", 0xFFFFFF).empty());
-        REQUIRE(AmsBackendCfs::slot_set_gcode(16, "PLA", 0xFFFFFF).empty());
+        REQUIRE(AmsBackendCfs::slot_set_gcode(-1, "PLA", 0xFFFFFF, "", "", 0).empty());
+        REQUIRE(AmsBackendCfs::slot_set_gcode(16, "PLA", 0xFFFFFF, "", "", 0).empty());
     }
 }
 

--- a/tests/unit/test_ams_cfs_flat_schema.cpp
+++ b/tests/unit/test_ams_cfs_flat_schema.cpp
@@ -35,7 +35,7 @@ json make_flat_box_json() {
         "driver_ready": true,
         "filament_detected": false,
         "filament_sensor_error": null,
-        "fluidd_widget_version": 2,
+        "api_version": 1,
         "humidity_pct": 22,
         "loaded_mask": 0,
         "loaded_slot": -1,
@@ -440,13 +440,13 @@ TEST_CASE("CFS Fork dialect: gcode builders", "[ams][cfs][flat][fork]") {
 
 // --- Fork dialect detection ------------------------------------------------
 
-TEST_CASE("CFS Fork dialect: detected from the module's own identity marker",
+TEST_CASE("CFS Fork dialect: detected from the supported Box API version",
           "[ams][cfs][flat][fork]") {
-    // `fluidd_widget_version` is box.py's own WIDGET_VERSION constant. It is a
-    // MODULE-identity marker, which is a stronger signal than schema shape:
+    // `api_version` explicitly identifies box.py's command dialect; `slots[]`
+    // alone only identifies which status parser to use:
     // the Fork commands are registered in Python, so they never appear in
     // printer.objects.list and has_macro("BOX_LOAD") can never see them.
-    SECTION("payload carrying the marker is the fork") {
+    SECTION("payload carrying the supported version is the fork") {
         REQUIRE(AmsBackendCfs::detect_fork_dialect(make_flat_box_json()) == true);
     }
 
@@ -454,12 +454,18 @@ TEST_CASE("CFS Fork dialect: detected from the module's own identity marker",
         REQUIRE(AmsBackendCfs::detect_fork_dialect(make_stock_box_json()) == false);
     }
 
-    SECTION("a flat payload without the marker is not assumed to be the fork") {
+    SECTION("a flat payload without api_version is not assumed to be the fork") {
         // Schema and dialect are separate axes. Another flat-schema firmware
         // would parse fine but must not inherit this one's command set.
         json box = make_flat_box_json();
-        box.erase("fluidd_widget_version");
+        box.erase("api_version");
         REQUIRE(AmsBackendCfs::detect_schema(box) == CfsSchema::Flat);
+        REQUIRE(AmsBackendCfs::detect_fork_dialect(box) == false);
+    }
+
+    SECTION("an unsupported API version is not assumed compatible") {
+        json box = make_flat_box_json();
+        box["api_version"] = 2;
         REQUIRE(AmsBackendCfs::detect_fork_dialect(box) == false);
     }
 }


### PR DESCRIPTION
## Summary

Fork Box operations are self-contained, so wrapping them in stock K2 orchestration causes invalid cleanup and duplicated command ownership.

- Use Box-owned `T<n>` and `BOX_UNLOAD` operations.
- Skip stock K2 homing and state/fan cleanup on the Fork path.
- Persist slot clears and full metadata through `_BOX_SLOT_CLEAR` and `_BOX_SLOT_SET`.

Fork routing remains gated by the existing `fluidd_widget_version` marker, keeping stock K1/K2 routing intact.