### PR TITLE
feat(portrait): stack the temperature graph above its control strip

### DIFF
--- a/src/ui/ui_overlay_temp_graph.cpp
+++ b/src/ui/ui_overlay_temp_graph.cpp
@@ -11,6 +11,7 @@
 #include "ui_utils.h"
 
 #include "app_globals.h"
+#include "layout_manager.h"
 #include "lvgl/src/others/translation/lv_translation.h"
 #include "panel_widget_manager.h"
 #include "printer_state.h"
@@ -547,16 +548,22 @@ void TempGraphOverlay::configure_control_strip() {
     if (chamber_strip_)
         lv_obj_add_flag(chamber_strip_, LV_OBJ_FLAG_HIDDEN);
 
-    if (mode_ == Mode::GraphOnly) {
-        // Graph takes full width — no right column
+    // In portrait the strip sits BELOW the graph (overlay_content flips to a
+    // column via bind_style_if on ui_is_portrait), so the graph keeps full
+    // width in every mode and this function must not fight the bound style —
+    // an imperative width outranks it.
+    const bool portrait = helix::is_portrait_layout(helix::LayoutManager::instance().type());
+
+    if (mode_ == Mode::GraphOnly || portrait) {
         if (graph_outer_)
             lv_obj_set_width(graph_outer_, lv_pct(100));
-        return;
+        if (mode_ == Mode::GraphOnly)
+            return;
+    } else {
+        // Landscape: graph gets 66% width with the control column beside it
+        if (graph_outer_)
+            lv_obj_set_width(graph_outer_, lv_pct(66));
     }
-
-    // Graph gets 66% width with control column visible
-    if (graph_outer_)
-        lv_obj_set_width(graph_outer_, lv_pct(66));
 
     // Determine which strip to show and heater type
     helix::HeaterType heater_type;

--- a/ui_xml/temp_graph_overlay.xml
+++ b/ui_xml/temp_graph_overlay.xml
@@ -4,18 +4,34 @@
 <component>
   <!-- Unified Temperature Graph Overlay -->
   <!-- Shows all temperature sensors with toggle chips and optional heater controls -->
+  <!-- Portrait reflow via bind_style_if on ui_is_portrait (see advanced_panel.xml
+       for the reasoning): only container direction and child sizing differ, so
+       no variant file. Both orientations carry explicit styles because an
+       inline attribute would outrank a bound style; the row/column styles set
+       layout=flex alongside flex_flow because a style sets only what it names. -->
+  <styles>
+    <style name="tg_content_row" layout="flex" flex_flow="row"/>
+    <style name="tg_content_column" layout="flex" flex_flow="column"/>
+    <style name="tg_graph_landscape" width="66%" height="100%" flex_grow="0"/>
+    <style name="tg_graph_portrait" width="100%" flex_grow="1" min_height="240"/>
+    <style name="tg_strip_landscape" width="33%" height="100%"/>
+    <style name="tg_strip_portrait" width="100%" height="content"/>
+  </styles>
   <view name="temp_graph_overlay" extends="overlay_panel" title="Temperature" title_tag="Temperature">
     <!-- Content area: graph+chips left, controls right (side-by-side) -->
     <lv_obj name="overlay_content"
-            width="100%" flex_grow="1" style_pad_all="#space_lg" style_pad_top="0" scrollable="false"
-            style_border_opa="0" flex_flow="row" style_flex_main_place="space_between">
+            width="100%" flex_grow="1" style_pad_all="#space_lg" style_pad_top="0" style_border_opa="0"
+            style_flex_main_place="space_between" style_pad_gap="#space_md">
+      <bind_style_if name="tg_content_column" cond="ui_is_portrait"/>
+      <bind_style_if name="tg_content_row" cond="ui_is_portrait" invert="true"/>
       <!-- Disable content when printer not connected or klippy not ready -->
       <bind_state_if_not_eq subject="nav_buttons_enabled" state="disabled" ref_value="1"/>
 
       <!-- Left column: Chip row + Temperature Graph -->
       <lv_obj name="graph_outer_container"
-              width="66%" height="100%" style_pad_all="0" scrollable="false" style_border_opa="0" flex_flow="column"
-              style_pad_gap="0">
+              style_pad_all="0" scrollable="false" style_border_opa="0" flex_flow="column" style_pad_gap="0">
+        <bind_style_if name="tg_graph_portrait" cond="ui_is_portrait"/>
+        <bind_style_if name="tg_graph_landscape" cond="ui_is_portrait" invert="true"/>
         <!-- Chip row: wrapping series toggle chips -->
         <lv_obj name="chip_row"
                 width="100%" height="content" style_pad_all="0" style_pad_bottom="#space_xs" style_border_opa="0"
@@ -33,8 +49,10 @@
       <!-- Right Column: NOZZLE controls (shown in nozzle mode only)      -->
       <!-- ════════════════════════════════════════════════════════════════ -->
       <lv_obj name="nozzle_control_strip"
-              width="33%" height="100%" style_pad_all="0" scrollable="false" style_border_opa="0" flex_flow="column"
-              style_flex_main_place="start" style_flex_cross_place="center" style_pad_gap="#space_sm" hidden="true">
+              style_pad_all="0" scrollable="false" style_border_opa="0" flex_flow="column" style_flex_main_place="start"
+              style_flex_cross_place="center" style_pad_gap="#space_sm" hidden="true">
+        <bind_style_if name="tg_strip_portrait" cond="ui_is_portrait"/>
+        <bind_style_if name="tg_strip_landscape" cond="ui_is_portrait" invert="true"/>
         <!-- Current/Target Temperature Display Card with Icon and Status -->
         <ui_card name="nozzle_display_card"
                  width="100%" height="content" style_radius="0" flex_flow="column" style_flex_main_place="center"
@@ -95,8 +113,10 @@
       <!-- Right Column: BED controls (shown in bed mode only)            -->
       <!-- ════════════════════════════════════════════════════════════════ -->
       <lv_obj name="bed_control_strip"
-              width="33%" height="100%" style_pad_all="0" scrollable="false" style_border_opa="0" flex_flow="column"
-              style_flex_main_place="start" style_flex_cross_place="center" style_pad_gap="#space_sm" hidden="true">
+              style_pad_all="0" scrollable="false" style_border_opa="0" flex_flow="column" style_flex_main_place="start"
+              style_flex_cross_place="center" style_pad_gap="#space_sm" hidden="true">
+        <bind_style_if name="tg_strip_portrait" cond="ui_is_portrait"/>
+        <bind_style_if name="tg_strip_landscape" cond="ui_is_portrait" invert="true"/>
         <ui_card name="bed_display_card"
                  width="100%" height="content" style_radius="0" flex_flow="column" style_flex_main_place="center"
                  style_pad_gap="#space_xs" style_pad_all="#space_sm">
@@ -146,8 +166,10 @@
       <!-- Right Column: CHAMBER controls (shown in chamber mode only)    -->
       <!-- ════════════════════════════════════════════════════════════════ -->
       <lv_obj name="chamber_control_strip"
-              width="33%" height="100%" style_pad_all="0" scrollable="false" style_border_opa="0" flex_flow="column"
-              style_flex_main_place="start" style_flex_cross_place="center" style_pad_gap="#space_sm" hidden="true">
+              style_pad_all="0" scrollable="false" style_border_opa="0" flex_flow="column" style_flex_main_place="start"
+              style_flex_cross_place="center" style_pad_gap="#space_sm" hidden="true">
+        <bind_style_if name="tg_strip_portrait" cond="ui_is_portrait"/>
+        <bind_style_if name="tg_strip_landscape" cond="ui_is_portrait" invert="true"/>
         <ui_card name="chamber_display_card"
                  width="100%" height="content" style_radius="0" flex_flow="column" style_flex_main_place="center"
                  style_pad_gap="#space_xs" style_pad_all="#space_sm">


### PR DESCRIPTION
Next in the sweep lane. First panel done with the inline bind_style_if recipe from #1238, and it carries one small panel-local C++ change flagged below.

## Problem

`temp_graph_overlay` is a landscape two-column layout: `graph_outer_container` at 66% beside a 33% per-heater control strip. In portrait that gives the graph a 200px-wide full-height ribbon, clips "Current / Target" in the display card, and floats the preset buttons over the plot area.

## Change

XML, following the advanced_panel pattern: `bind_style_if` pairs on `ui_is_portrait`. `overlay_content` flips row/column, and the graph plus all three control strips move their inline sizes into explicit landscape styles so the portrait styles can win. Portrait puts the graph on top at full width with `flex_grow` and a 240px `min_height` floor, and the strip below at content height. `overlay_content` becomes scrollable so short screens scroll past the floor instead of crushing the graph. In landscape everything fits, so scrolling never engages.

**C++, one function, flagged for your review:** `configure_control_strip()` imperatively sets `graph_outer_` to `lv_pct(66)` whenever a strip is visible, and an imperative width outranks the bound style, so XML alone cannot win. The two width writes now check `helix::is_portrait_layout()` (the idiom your print_status seam uses) and keep the graph at 100% in portrait. GraphOnly mode was already full width; no other behavior changes. If you'd rather own that piece, happy to drop it from this PR.

## Verification

Measured with `helix-screen ctl geom graph_outer_container`:

| Size | before | after |
|---|---|---|
| 320x1480 | w=200 ribbon, presets over the plot | graph w=304 h=821 on top, strip w=304 h=417 below |
| 480x800 | same two-column crush | graph w=448 h=240 (floor) |
| 272x480 | same | graph w=256 h=240 (floor; presets scroll below) |
| 800x480 landscape control | — | graph w=446 beside strip w=223, unchanged |

Tests: `[action_prompt]` has 3 pre-existing assertion failures that are identical on clean main with this change stashed. `[theme],[layout],[xml]` otherwise green. Lint and all commit gates pass.

Screenshots in a follow-up comment: 320x1480, 480x800, 272x480, plus the landscape control.