### PR TITLE
ci(release): fix the Pi/release build timeout at its root — warm the ccache on main

### DIFF
--- a/.github/workflows/ccache-warm.yml
+++ b/.github/workflows/ccache-warm.yml
@@ -1,0 +1,131 @@
+name: Warm release ccache
+
+# Why this exists
+# ----------------
+# The Release workflow triggers on tags (refs/tags/vX.Y.Z). GitHub Actions scopes
+# every cache by git ref, and a tag run can only restore caches from its own tag
+# scope (always empty — each tag is brand new) or the default branch's scope. Tag
+# runs can never read each other's caches, so no release ever restored the
+# previous release's ccache: every release cross-compile ran 100% cold (measured
+# ~1% hit across all platforms in the v0.99.107 logs). The heavy DRM+GLES+thorvg
+# targets (pi, pi32, x86) sit at 58-70 min because of it and creep toward the
+# job timeout as the tree grows.
+#
+# This workflow runs on `main`, so the ccache it saves lands in the DEFAULT
+# BRANCH scope — the one scope a release tag *can* restore from. The release job
+# reads it restore-only (see release.yml "Restore ccache"). It compiles with the
+# exact same toolchain image, mount, and make invocation as the release so the
+# cached objects match.
+#
+# Only the three heavy platforms are warmed: they are the only ones near the
+# timeout, and three ccaches (~1.7 GB each ≈ 5 GB) stay comfortably inside
+# GitHub's 10 GB per-repo cache budget. The light platforms (~35-47 min) have
+# ample headroom and are intentionally left to build cold.
+#
+# depend_mode is intentionally NOT enabled. The global -DHELIX_VERSION define
+# changes every release, which sinks ccache direct-mode hits; ccache's
+# preprocessed fallback excludes -D from its hash, so unchanged TUs still hit —
+# but only while preprocessed mode is available, which depend_mode would disable.
+
+on:
+  schedule:
+    # 06:00 UTC daily — after the 04:00 nightly, so a warm cache is waiting for
+    # any release cut during the day. Cadence, not freshness, is the tradeoff:
+    # a release lands as many hits as the last warm run's tree shares with it.
+    - cron: '0 6 * * *'
+  workflow_dispatch:  # Warm on demand right before cutting a release.
+
+# One warm run at a time; a newer push supersedes an in-flight one.
+concurrency:
+  group: ccache-warm
+  cancel-in-progress: true
+
+jobs:
+  warm:
+    name: Warm (${{ matrix.display_name }})
+    # Upstream only — forks neither release nor share this repo's cache budget.
+    if: github.repository == 'prestonbrown/helixscreen'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: pi
+            display_name: "Raspberry Pi"
+            build_target: pi-both
+          - platform: pi32
+            display_name: "Raspberry Pi 32-bit"
+            build_target: pi32-both
+          - platform: x86
+            display_name: "x86_64 Debian"
+            build_target: x86-both
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: false
+
+    - name: Initialize submodules
+      uses: ./.github/actions/init-submodules
+
+    # Mirror the release job: the heavy cross-compiles write GCC assembler temp
+    # files and ccache to a root partition the runner ships nearly full.
+    - name: Free up disk space
+      run: |
+        df -h /
+        sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+        df -h /
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    # Save+restore (unlike the release, which is restore-only). The unique run_id
+    # suffix guarantees a fresh save every run — a fixed key would hit on the
+    # primary key and actions/cache would then skip the save, freezing the cache.
+    # restore-keys still restores the most recent prior warm cache to build on.
+    - name: Cache ccache
+      uses: actions/cache@v5
+      with:
+        path: /tmp/.ccache-${{ matrix.platform }}
+        key: ccache-release-${{ matrix.platform }}-${{ github.run_id }}
+        restore-keys: |
+          ccache-release-${{ matrix.platform }}-
+
+    - name: Configure ccache
+      run: |
+        mkdir -p /tmp/.ccache-${{ matrix.platform }}
+        printf 'max_size = 2G\ncompression = true\n' > /tmp/.ccache-${{ matrix.platform }}/ccache.conf
+
+    - name: Build ${{ matrix.platform }} toolchain image
+      # Same type=gha scope the release uses, so this also warms the toolchain
+      # image cache (default-branch scope) that the release restores.
+      run: |
+        docker buildx build \
+          --cache-from type=gha,scope=toolchain-${{ matrix.platform }} \
+          --cache-to type=gha,mode=max,scope=toolchain-${{ matrix.platform }} \
+          --load \
+          -t helixscreen/toolchain-${{ matrix.platform }} \
+          -f docker/Dockerfile.${{ matrix.platform }} \
+          docker/
+
+    # Identical to the release cross-compile step (same image, mount, make flags)
+    # so the ccache objects this produces are the ones the release will look up.
+    # No packaging, symbols, or image generation — the objects in ccache are the
+    # entire product of this job.
+    - name: Cross-compile for ${{ matrix.display_name }} (warm cache only)
+      run: |
+        docker run --rm \
+          -v "${{ github.workspace }}":/src \
+          -v /tmp/.ccache-${{ matrix.platform }}:/root/.cache/ccache \
+          -w /src \
+          helixscreen/toolchain-${{ matrix.platform }} \
+          make PLATFORM_TARGET=${{ matrix.build_target }} SKIP_OPTIONAL_DEPS=1 -j$(nproc)
+
+    - name: Show ccache stats
+      run: |
+        docker run --rm \
+          -v /tmp/.ccache-${{ matrix.platform }}:/root/.cache/ccache \
+          helixscreen/toolchain-${{ matrix.platform }} \
+          ccache -s

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,15 @@ jobs:
     name: Build (${{ matrix.display_name }})
     needs: [validate-shell]
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    # The pi-both / pi32-both / x86-both cross-compiles are the long poles here:
+    # a full DRM+GLES+thorvg build that lands at 58-70 min and grows with the
+    # codebase, so 90 left almost no headroom (v0.99.108's pi64 job died at ~75
+    # min). ccache does not reliably survive between releases — 9 platform
+    # ccaches plus the type=gha toolchain caches overrun GitHub's 10 GB/repo
+    # cache budget and get evicted LRU — so builds run near-cold every time.
+    # 120 is margin, not a fix; the durable fix is cache survival (or splitting
+    # the Pi build). Other platforms finish in ~35-47 min and never approach it.
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,18 +113,26 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
-    - name: Compute ccache bucket
-      id: ccache-bucket
-      run: echo "month=$(date -u +%Y-%m)" >> $GITHUB_OUTPUT
-
-    - name: Cache ccache
-      uses: actions/cache@v5
+    # Restore-only, and it reads a cache warmed on the default branch — never one
+    # from a sibling release. A release runs on a tag ref (refs/tags/vX.Y.Z),
+    # whose only readable cache scopes are its own (always empty — every tag is
+    # new) and the default branch. Tag runs can never see each other's caches, so
+    # keying by SHA, by tag, or by month made no difference: every release built
+    # 100% cold (measured ~1% ccache hit across all platforms, v0.99.107 logs).
+    # The ccache-warm workflow now compiles the heavy platforms on `main` and
+    # saves ccache-release-<plat>-* into the default-branch scope; this restore
+    # picks it up via the prefix. depend_mode is intentionally NOT set (here or in
+    # the warmer): the global -DHELIX_VERSION changes each release and would sink
+    # direct-mode hits, but ccache's preprocessed fallback excludes -D from its
+    # hash, so the ~99% of TUs that don't read the version macro still hit.
+    - name: Restore ccache (warmed on main — see ccache-warm.yml)
+      uses: actions/cache/restore@v5
       with:
         path: /tmp/.ccache-${{ matrix.docker_image || matrix.platform }}
-        # Monthly bucket so the primary key is stable across tag pushes (prior
-        # SHA-based keys never hit on tag-scoped cache and the cache never
-        # warmed). Restore-keys still fall through to any older bucket.
-        key: ccache-release-${{ matrix.docker_image || matrix.platform }}-${{ steps.ccache-bucket.outputs.month }}
+        # Restore-only on purpose: a release must not SAVE a cache. Its save would
+        # land in the unreadable tag scope, and 9 platforms x ~1.7 GB of such dead
+        # caches would evict the warmed ones under GitHub's 10 GB per-repo budget.
+        key: ccache-release-${{ matrix.docker_image || matrix.platform }}-restore
         restore-keys: |
           ccache-release-${{ matrix.docker_image || matrix.platform }}-
 


### PR DESCRIPTION
## Why

v0.99.108's release run was cancelled after the **Raspberry Pi 64-bit** cross-compile exited non-zero at ~75 min. That was *not* a clean 90-min timeout (it died 15 min under the ceiling, and the same commit built fine for Android arm64 and Pi 32-bit) — but it exposed how close the heavy builds run to the wall. The re-run passed with no code change, confirming the failure was transient.

Investigating the underlying slowness turned up the real problem: **every release cross-compile has been building 100% cold.** The v0.99.107 logs show `Cache not found` for all ten platforms and a measured **~1% ccache hit rate**. GitHub scopes caches by git ref; releases run on a **tag** ref whose only readable scopes are its own (always empty) and the default branch (also empty, since releases never run on `main`). So no release could ever restore the previous one's cache — keying by SHA, tag, or month made no difference, because the limit is ref-scoping, not the key. The April "repair" fixed caching *within* a build but couldn't touch cross-release restore.

## What

- **`ci(release): raise platform-build timeout 90 → 120 min`** — immediate headroom for the pi/pi32/x86 long poles (58–70 min and growing). Insurance, not the fix.
- **`ci(release): warm the release ccache on main`**
  - **`ccache-warm.yml`** (new): runs on `main` (daily 06:00 UTC + manual dispatch) and cross-compiles the three heavy platforms with the *exact* toolchain image, mount, and make invocation the release uses, saving `ccache-release-<plat>-*` into the **default-branch cache scope** — the one scope a release tag can restore from. Only the three heavy platforms are warmed, so three ~1.7 GB caches stay under GitHub's 10 GB/repo budget.
  - **`release.yml`**: platform ccache step switched to **restore-only**. A release must not *save* — its save lands in the unreadable tag scope, and nine platforms × ~1.7 GB of dead caches would evict the warmed ones under the 10 GB budget.
  - `depend_mode` is deliberately left off in both: the global `-DHELIX_VERSION` changes every release and sinks direct-mode hits, but ccache's preprocessed fallback excludes `-D` from its hash, so the ~99% of TUs that don't read the version macro still hit — a fallback `depend_mode` would disable.

## Rollout / validation

Effective for the **next** release, not a retroactive fix. After merge, trigger **Warm release ccache** once (Actions → workflow_dispatch) so `main`'s cache scope is populated before the next tag; otherwise the first post-merge release still builds cold and warms on the following schedule. A GitHub cache-scoping fix can't be proven locally — the first warmed release is where the ~1% hit rate should jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVmdJrMmmHufRjkdYKQ7Pn

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVmdJrMmmHufRjkdYKQ7Pn)_