### PR TITLE
refactor(temp-graph): declarative mode + portrait compact card

### DIFF
--- a/include/ui_overlay_temp_graph.h
+++ b/include/ui_overlay_temp_graph.h
@@ -135,10 +135,15 @@ class TempGraphOverlay : public OverlayBase {
 
     // State
     Mode mode_ = Mode::GraphOnly;
+
+    // Declarative mode subject (0=GraphOnly, 1=Nozzle, 2=Bed, 3=Chamber).
+    // Drives strip visibility and graph_outer width from XML — see
+    // temp_graph_overlay.xml's <subjects> block. Seeded with mode_ by
+    // init_subjects(); synced on every open() call.
+    lv_subject_t mode_subject_{};
     std::unique_ptr<helix::TempGraphController> controller_;
     lv_obj_t* chip_row_ = nullptr;
     lv_obj_t* graph_container_ = nullptr;
-    lv_obj_t* graph_outer_ = nullptr;
     lv_obj_t* nozzle_strip_ = nullptr;
     lv_obj_t* bed_strip_ = nullptr;
     lv_obj_t* chamber_strip_ = nullptr;

--- a/src/ui/ui_overlay_temp_graph.cpp
+++ b/src/ui/ui_overlay_temp_graph.cpp
@@ -11,7 +11,6 @@
 #include "ui_utils.h"
 
 #include "app_globals.h"
-#include "layout_manager.h"
 #include "lvgl/src/others/translation/lv_translation.h"
 #include "panel_widget_manager.h"
 #include "printer_state.h"
@@ -119,7 +118,13 @@ TempGraphOverlay::~TempGraphOverlay() {
 // ─────────────────────────────────────────────────────────────────────────────
 
 void TempGraphOverlay::init_subjects() {
-    init_subjects_guarded([]() {});
+    init_subjects_guarded([this]() {
+        // mode_ is set by open() before this first runs; seeding the subject
+        // with the current value avoids a transient wrong-mode frame between
+        // XML create and the first lv_subject_set_int in open().
+        UI_MANAGED_SUBJECT_INT(mode_subject_, static_cast<int>(mode_), "temp_graph_mode",
+                               subjects_);
+    });
 }
 
 void TempGraphOverlay::register_callbacks() {
@@ -137,7 +142,6 @@ lv_obj_t* TempGraphOverlay::create(lv_obj_t* parent) {
     bed_strip_ = lv_obj_find_by_name(overlay_root_, "bed_control_strip");
     chamber_strip_ = lv_obj_find_by_name(overlay_root_, "chamber_control_strip");
     extruder_selector_row_ = lv_obj_find_by_name(overlay_root_, "extruder_selector_row");
-    graph_outer_ = lv_obj_find_by_name(overlay_root_, "graph_outer_container");
 
     return overlay_root_;
 }
@@ -262,6 +266,15 @@ void TempGraphOverlay::open(Mode mode, lv_obj_t* parent_screen) {
 
         NavigationManager::instance().register_overlay_instance(cached_overlay_, this, true);
         spdlog::info("[TempGraphOverlay] Overlay created");
+    }
+
+    // Sync the declarative mode subject on every open. Idempotent on the first
+    // open (init_subjects already seeded it with mode_), but necessary for
+    // subsequent opens where the caller chose a different mode than last time.
+    // XML bindings (strip visibility via bind_flag_if_not_eq, graph_outer width
+    // via temp_graph_full_width subject_expr) refire and reflow the overlay.
+    if (are_subjects_initialized()) {
+        lv_subject_set_int(&mode_subject_, static_cast<int>(mode_));
     }
 
     if (cached_overlay_) {
@@ -540,32 +553,13 @@ void TempGraphOverlay::update_chip_style(size_t series_idx) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 void TempGraphOverlay::configure_control_strip() {
-    // Hide all strips first
-    if (nozzle_strip_)
-        lv_obj_add_flag(nozzle_strip_, LV_OBJ_FLAG_HIDDEN);
-    if (bed_strip_)
-        lv_obj_add_flag(bed_strip_, LV_OBJ_FLAG_HIDDEN);
-    if (chamber_strip_)
-        lv_obj_add_flag(chamber_strip_, LV_OBJ_FLAG_HIDDEN);
+    // DECLARATIVE: strip visibility and graph_outer width are driven from XML
+    // by the temp_graph_mode subject (bind_flag_if_not_eq per strip; graph width
+    // via the temp_graph_full_width subject_expr + orthogonal bind_style_if
+    // pairs on graph_outer_container). This function is now the DATA half only:
+    // preset values, callback user_data, and the chamber-async-clamp that can't
+    // move to XML because it depends on the fetched chamber max_temp.
 
-    // In portrait the strip sits BELOW the graph (overlay_content flips to a
-    // column via bind_style_if on ui_is_portrait), so the graph keeps full
-    // width in every mode and this function must not fight the bound style —
-    // an imperative width outranks it.
-    const bool portrait = helix::is_portrait_layout(helix::LayoutManager::instance().type());
-
-    if (mode_ == Mode::GraphOnly || portrait) {
-        if (graph_outer_)
-            lv_obj_set_width(graph_outer_, lv_pct(100));
-        if (mode_ == Mode::GraphOnly)
-            return;
-    } else {
-        // Landscape: graph gets 66% width with the control column beside it
-        if (graph_outer_)
-            lv_obj_set_width(graph_outer_, lv_pct(66));
-    }
-
-    // Determine which strip to show and heater type
     helix::HeaterType heater_type;
     if (!mode_to_heater_type(mode_, heater_type))
         return;
@@ -587,7 +581,6 @@ void TempGraphOverlay::configure_control_strip() {
 
     if (!active_strip)
         return;
-    lv_obj_remove_flag(active_strip, LV_OBJ_FLAG_HIDDEN);
 
     // Get preset config from TemperatureService
     if (!temp_control_panel_)

--- a/ui_xml/temp_graph_overlay.xml
+++ b/ui_xml/temp_graph_overlay.xml
@@ -4,24 +4,56 @@
 <component>
   <!-- Unified Temperature Graph Overlay -->
   <!-- Shows all temperature sensors with toggle chips and optional heater controls -->
-  <!-- Portrait reflow via bind_style_if on ui_is_portrait (see advanced_panel.xml
-       for the reasoning): only container direction and child sizing differ, so
-       no variant file. Both orientations carry explicit styles because an
-       inline attribute would outrank a bound style; the row/column styles set
-       layout=flex alongside flex_flow because a style sets only what it names. -->
+
+  <!-- Two independent axes drive the layout:
+       * orientation (ui_is_portrait) — overlay_content's flex direction,
+         graph_outer's container behavior (flex_grow vs full height),
+         and each strip's width/height.
+       * mode (temp_graph_mode: 0=GraphOnly, 1=Nozzle, 2=Bed, 3=Chamber,
+         set by TempGraphOverlay::open) — which control strip is visible,
+         and whether graph_outer takes the full width or shares with a strip.
+       The width decision is the one place both axes meet: full when GraphOnly
+       OR portrait (no strip beside the graph), 66% otherwise. Expressed as
+       inline cond= on graph_outer's bind_style_if pair rather than a
+       <subject_expr>, because subject_expr is evaluated at component-load
+       time (Phase 8c) while temp_graph_mode is only registered by
+       TempGraphOverlay::init_subjects() (Phase 9a). cond= on bind_style_if
+       compiles at view-creation time, after init_subjects has run. -->
+
+  <!-- Both orientations carry explicit styles because an inline attribute would
+       outrank a bound style; the row/column styles set layout=flex alongside
+       flex_flow because a style sets only what it names. Width and container
+       behavior are split into orthogonal pairs so a 4-state cross product
+       isn't needed: graph_outer carries one width-axis bind_style_if pair
+       (mode-driven via inline cond=) and one container-axis pair
+       (orientation-driven). -->
   <styles>
     <style name="tg_content_row" layout="flex" flex_flow="row"/>
     <style name="tg_content_column" layout="flex" flex_flow="column"/>
-    <style name="tg_graph_landscape" width="66%" height="100%" flex_grow="0"/>
-    <style name="tg_graph_portrait" width="100%" flex_grow="1" min_height="240"/>
-    <style name="tg_strip_landscape" width="33%" height="100%"/>
-    <style name="tg_strip_portrait" width="100%" height="content"/>
+    <!-- graph_outer width axis: full when GraphOnly OR portrait, else 66%. -->
+    <style name="tg_graph_full" width="100%"/>
+    <style name="tg_graph_two_col" width="66%"/>
+    <!-- graph_outer container axis (ui_is_portrait). No min_height floor —
+         flex_grow gives the graph whatever's left after the strip claims
+         content height, so the tightest portrait target (272x480: ~180px
+         graph after the chip row + nozzle strip) fits without forcing
+         overlay_content to scroll. A floor large enough to matter would
+         re-introduce the scroll the floor was working around. -->
+    <style name="tg_graph_portrait" flex_grow="1"/>
+    <style name="tg_graph_landscape" height="100%" flex_grow="0"/>
+    <!-- strip orientation axis. Carries layout=flex AND flex_flow because a
+         style sets only what it names; the strip elements have no inline
+         flex_flow (inline would override the bind per AGENTS.md rule 6). -->
+    <style name="tg_strip_landscape" layout="flex" flex_flow="column" width="33%" height="100%"
+           style_flex_main_place="start" style_flex_cross_place="center"/>
+    <style name="tg_strip_portrait" layout="flex" flex_flow="row" width="100%" height="content"
+           style_flex_main_place="start" style_flex_cross_place="center"/>
   </styles>
   <view name="temp_graph_overlay" extends="overlay_panel" title="Temperature" title_tag="Temperature">
     <!-- Content area: graph+chips left, controls right (side-by-side) -->
     <lv_obj name="overlay_content"
-            width="100%" flex_grow="1" style_pad_all="#space_lg" style_pad_top="0" style_border_opa="0"
-            style_flex_main_place="space_between" style_pad_gap="#space_md">
+            width="100%" flex_grow="1" style_pad_all="#space_lg" style_pad_top="0" scrollable="false"
+            style_border_opa="0" style_flex_main_place="space_between" style_pad_gap="#space_md">
       <bind_style_if name="tg_content_column" cond="ui_is_portrait"/>
       <bind_style_if name="tg_content_row" cond="ui_is_portrait" invert="true"/>
       <!-- Disable content when printer not connected or klippy not ready -->
@@ -30,6 +62,10 @@
       <!-- Left column: Chip row + Temperature Graph -->
       <lv_obj name="graph_outer_container"
               style_pad_all="0" scrollable="false" style_border_opa="0" flex_flow="column" style_pad_gap="0">
+        <!-- Width axis: inline cond= (not subject_expr) so this evaluates at
+             view creation, after temp_graph_mode is registered. -->
+        <bind_style_if name="tg_graph_full" cond="ui_is_portrait or temp_graph_mode eq 0"/>
+        <bind_style_if name="tg_graph_two_col" cond="ui_is_portrait or temp_graph_mode eq 0" invert="true"/>
         <bind_style_if name="tg_graph_portrait" cond="ui_is_portrait"/>
         <bind_style_if name="tg_graph_landscape" cond="ui_is_portrait" invert="true"/>
         <!-- Chip row: wrapping series toggle chips -->
@@ -49,175 +85,353 @@
       <!-- Right Column: NOZZLE controls (shown in nozzle mode only)      -->
       <!-- ════════════════════════════════════════════════════════════════ -->
       <lv_obj name="nozzle_control_strip"
-              style_pad_all="0" scrollable="false" style_border_opa="0" flex_flow="column" style_flex_main_place="start"
-              style_flex_cross_place="center" style_pad_gap="#space_sm" hidden="true">
+              style_pad_all="0" scrollable="false" style_border_opa="0"
+              style_pad_gap="#space_sm" hidden="true">
+        <!-- Show only in Nozzle mode (temp_graph_mode == 1). bind_flag_if_not_eq
+             adds `hidden` when the condition is met (mode != 1) and removes it
+             otherwise — so the inline hidden="true" is just the initial state
+             before the binding fires. -->
+        <bind_flag_if_not_eq subject="temp_graph_mode" flag="hidden" ref_value="1"/>
         <bind_style_if name="tg_strip_portrait" cond="ui_is_portrait"/>
         <bind_style_if name="tg_strip_landscape" cond="ui_is_portrait" invert="true"/>
-        <!-- Current/Target Temperature Display Card with Icon and Status -->
-        <ui_card name="nozzle_display_card"
-                 width="100%" height="content" style_radius="0" flex_flow="column" style_flex_main_place="center"
-                 style_pad_gap="#space_xs" style_pad_all="#space_sm">
-          <lv_obj width="100%" flex_flow="row" style_pad_all="0" scrollable="false">
-            <lv_obj height="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
-            <lv_obj height="content"
-                    flex_flow="column" style_flex_cross_place="start" style_pad_all="0" style_pad_gap="#space_xs"
-                    scrollable="false">
-              <nozzle_icon name="nozzle_heater_icon" size="xl"/>
-              <lv_obj style_pad_all="0"
-                      scrollable="false" flex_flow="column" style_flex_main_place="center"
-                      style_flex_cross_place="start" style_pad_gap="#space_xxs">
-                <text_small style_border_width="0" text="Current / Target" translation_tag="Current / Target"/>
-                <temp_display name="nozzle_temp_display"
-                              size="lg" show_target="true" bind_current="extruder_temp" bind_target="extruder_target"/>
+
+        <!-- Structural <if>: landscape is a single column with a centered xl
+             card; portrait is a row with a compact card on the left and a
+             right-column controls wrapper. The card's internals differ enough
+             (icon size is creation-time, not styleable) that <if> is cleaner
+             than restyle. Only the matching branch is built — runtime
+             portrait/landscape flipping isn't supported, so no rebuild cost.
+             Names repeat across branches; check_duplicate_xml_names.py skips
+             <if>/<else> branch pairs by design. temp_display carries
+             event_cb="on_temp_graph_custom_clicked" so clicking the temp
+             opens the keypad (works in both orientations). -->
+        <if cond="ui_is_portrait eq 0">
+          <!-- LANDSCAPE: full-width centered xl-icon card, then extruder
+               selector, spacer, preset grid (2×2), Custom. -->
+          <ui_card name="nozzle_display_card"
+                   width="100%" height="content" style_radius="0" flex_flow="column" style_flex_main_place="center"
+                   style_pad_gap="#space_xs" style_pad_all="#space_sm">
+            <lv_obj width="100%" flex_flow="row" style_pad_all="0" scrollable="false">
+              <lv_obj height="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
+              <lv_obj height="content"
+                      flex_flow="column" style_flex_cross_place="start" style_pad_all="0" style_pad_gap="#space_xs"
+                      scrollable="false">
+                <nozzle_icon name="nozzle_heater_icon" size="xl"/>
+                <lv_obj style_pad_all="0"
+                        scrollable="false" flex_flow="column" style_flex_main_place="center"
+                        style_flex_cross_place="start" style_pad_gap="#space_xxs">
+                  <text_small style_border_width="0" text="Current / Target" translation_tag="Current / Target"/>
+                  <temp_display name="nozzle_temp_display"
+                                size="lg" show_target="true" bind_current="extruder_temp" bind_target="extruder_target"
+                                event_cb="on_temp_graph_custom_clicked"/>
+                </lv_obj>
+                <text_small name="nozzle_status_msg"
+                            style_border_width="0" bind_text="nozzle_status" style_text_align="left"/>
               </lv_obj>
-              <text_small name="nozzle_status_msg"
-                          style_border_width="0" bind_text="nozzle_status" style_text_align="left"/>
+              <lv_obj height="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
             </lv_obj>
-            <lv_obj height="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
+          </ui_card>
+          <!-- Extruder selector (shown when multiple extruders detected) -->
+          <lv_obj name="extruder_selector_row"
+                  width="100%" height="content" style_pad_all="0" scrollable="false" style_border_opa="0" flex_flow="row"
+                  style_pad_gap="#space_xs" style_flex_main_place="center" hidden="true">
+            <!-- Populated programmatically in C++ -->
           </lv_obj>
-        </ui_card>
-        <!-- Extruder selector (shown when multiple extruders detected) -->
-        <lv_obj name="extruder_selector_row"
-                width="100%" height="content" style_pad_all="0" scrollable="false" style_border_opa="0" flex_flow="row"
-                style_pad_gap="#space_xs" style_flex_main_place="center" hidden="true">
-          <!-- Populated programmatically in C++ -->
-        </lv_obj>
-        <!-- Spacer -->
-        <lv_obj width="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
-        <!-- Preset buttons -->
-        <lv_obj name="nozzle_preset_grid"
-                width="100%" height="content" style_pad_all="0" scrollable="false" flex_flow="row_wrap"
-                style_flex_main_place="space_between" style_pad_gap="#space_xs">
-          <ui_button name="preset_off"
-                     width="48%" text="Off" translation_tag="Off" variant="ghost" style_border_width="#border_width"
-                     style_border_color="#border" style_border_opa="255">
-            <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+          <!-- Spacer -->
+          <lv_obj width="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
+          <!-- Preset buttons -->
+          <lv_obj name="nozzle_preset_grid"
+                  width="100%" height="content" style_pad_all="0" scrollable="false" flex_flow="row_wrap"
+                  style_flex_main_place="space_between" style_pad_gap="#space_xs">
+            <ui_button name="preset_off"
+                       width="48%" text="Off" translation_tag="Off" variant="ghost" style_border_width="#border_width"
+                       style_border_color="#border" style_border_opa="255">
+              <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+            </ui_button>
+            <ui_button name="preset_1" width="48%" bind_text="preset_material_0_name">
+              <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+            </ui_button>
+            <ui_button name="preset_2" width="48%" bind_text="preset_material_1_name">
+              <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+            </ui_button>
+            <ui_button name="preset_3" width="48%" bind_text="preset_material_2_name">
+              <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+            </ui_button>
+          </lv_obj>
+          <ui_button name="nozzle_btn_custom"
+                     width="100%" text="Custom..." translation_tag="Custom..." variant="secondary">
+            <event_cb trigger="clicked" callback="on_temp_graph_custom_clicked"/>
           </ui_button>
-          <ui_button name="preset_1" width="48%" bind_text="preset_material_0_name">
-            <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
-          </ui_button>
-          <ui_button name="preset_2" width="48%" bind_text="preset_material_1_name">
-            <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
-          </ui_button>
-          <ui_button name="preset_3" width="48%" bind_text="preset_material_2_name">
-            <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
-          </ui_button>
-        </lv_obj>
-        <ui_button name="nozzle_btn_custom"
-                   width="100%" text="Custom..." translation_tag="Custom..." variant="secondary">
-          <event_cb trigger="clicked" callback="on_temp_graph_custom_clicked"/>
-        </ui_button>
+          <else/>
+          <!-- PORTRAIT: row with compact card on the left, controls column on
+               the right. Compact card uses size="md" icon + size="md" temp +
+               status, sized to content width — drops the centered xl layout
+               that eats vertical space at the cost of a narrower display. The
+               card is wrapped in a full-height column container that vertically
+               centers it against the taller right column — LVGL flex's
+               cross_place on the strip style doesn't reliably center
+               content-height items, so we wrap explicitly. The right column
+               holds the extruder selector, preset grid (still 2×2 but at
+               narrower width), and Custom button. -->
+          <lv_obj height="100%" width="content" flex_flow="column"
+                  style_flex_main_place="center" style_pad_all="0"
+                  scrollable="false" style_border_opa="0">
+            <ui_card name="nozzle_display_card"
+                     width="content" height="content" style_radius="0" flex_flow="column"
+                     style_flex_main_place="center" style_flex_cross_place="center"
+                     style_pad_gap="#space_xs" style_pad_all="#space_sm">
+              <nozzle_icon name="nozzle_heater_icon" size="md"/>
+              <temp_display name="nozzle_temp_display"
+                            size="md" show_target="true" bind_current="extruder_temp" bind_target="extruder_target"
+                            event_cb="on_temp_graph_custom_clicked"/>
+              <text_small name="nozzle_status_msg"
+                          style_border_width="0" bind_text="nozzle_status" style_text_align="center"/>
+            </ui_card>
+          </lv_obj>
+          <lv_obj flex_grow="1" height="content" flex_flow="column"
+                  style_pad_all="0" style_pad_gap="#space_sm" scrollable="false" style_border_opa="0">
+            <lv_obj name="extruder_selector_row"
+                    width="100%" height="content" style_pad_all="0" scrollable="false" style_border_opa="0" flex_flow="row"
+                    style_pad_gap="#space_xs" style_flex_main_place="center" hidden="true">
+              <!-- Populated programmatically in C++ -->
+            </lv_obj>
+            <lv_obj name="nozzle_preset_grid"
+                    width="100%" height="content" style_pad_all="0" scrollable="false" flex_flow="row_wrap"
+                    style_flex_main_place="space_between" style_pad_gap="#space_xs">
+              <ui_button name="preset_off"
+                         width="48%" text="Off" translation_tag="Off" variant="ghost" style_border_width="#border_width"
+                         style_border_color="#border" style_border_opa="255">
+                <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+              </ui_button>
+              <ui_button name="preset_1" width="48%" bind_text="preset_material_0_name">
+                <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+              </ui_button>
+              <ui_button name="preset_2" width="48%" bind_text="preset_material_1_name">
+                <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+              </ui_button>
+              <ui_button name="preset_3" width="48%" bind_text="preset_material_2_name">
+                <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+              </ui_button>
+            </lv_obj>
+            <ui_button name="nozzle_btn_custom"
+                       width="100%" text="Custom..." translation_tag="Custom..." variant="secondary">
+              <event_cb trigger="clicked" callback="on_temp_graph_custom_clicked"/>
+            </ui_button>
+          </lv_obj>
+        </if>
       </lv_obj>
 
       <!-- ════════════════════════════════════════════════════════════════ -->
       <!-- Right Column: BED controls (shown in bed mode only)            -->
       <!-- ════════════════════════════════════════════════════════════════ -->
       <lv_obj name="bed_control_strip"
-              style_pad_all="0" scrollable="false" style_border_opa="0" flex_flow="column" style_flex_main_place="start"
-              style_flex_cross_place="center" style_pad_gap="#space_sm" hidden="true">
+              style_pad_all="0" scrollable="false" style_border_opa="0"
+              style_pad_gap="#space_sm" hidden="true">
+        <bind_flag_if_not_eq subject="temp_graph_mode" flag="hidden" ref_value="2"/>
         <bind_style_if name="tg_strip_portrait" cond="ui_is_portrait"/>
         <bind_style_if name="tg_strip_landscape" cond="ui_is_portrait" invert="true"/>
-        <ui_card name="bed_display_card"
-                 width="100%" height="content" style_radius="0" flex_flow="column" style_flex_main_place="center"
-                 style_pad_gap="#space_xs" style_pad_all="#space_sm">
-          <lv_obj width="100%" flex_flow="row" style_pad_all="0" scrollable="false">
-            <lv_obj height="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
-            <lv_obj height="content"
-                    flex_flow="column" style_flex_cross_place="start" style_pad_all="0" style_pad_gap="#space_xs"
-                    scrollable="false">
-              <heater_icon src="radiator" glyph_name="bed_icon_glyph" size="xl"/>
-              <lv_obj style_pad_all="0"
-                      scrollable="false" flex_flow="column" style_flex_main_place="center"
-                      style_flex_cross_place="start" style_pad_gap="#space_xxs">
-                <text_small text="Current / Target" translation_tag="Current / Target"/>
-                <temp_display name="bed_temp_display"
-                              size="lg" show_target="true" bind_current="bed_temp" bind_target="bed_target"/>
+
+        <if cond="ui_is_portrait eq 0">
+          <!-- LANDSCAPE -->
+          <ui_card name="bed_display_card"
+                   width="100%" height="content" style_radius="0" flex_flow="column" style_flex_main_place="center"
+                   style_pad_gap="#space_xs" style_pad_all="#space_sm">
+            <lv_obj width="100%" flex_flow="row" style_pad_all="0" scrollable="false">
+              <lv_obj height="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
+              <lv_obj height="content"
+                      flex_flow="column" style_flex_cross_place="start" style_pad_all="0" style_pad_gap="#space_xs"
+                      scrollable="false">
+                <heater_icon src="radiator" glyph_name="bed_icon_glyph" size="xl"/>
+                <lv_obj style_pad_all="0"
+                        scrollable="false" flex_flow="column" style_flex_main_place="center"
+                        style_flex_cross_place="start" style_pad_gap="#space_xxs">
+                  <text_small text="Current / Target" translation_tag="Current / Target"/>
+                  <temp_display name="bed_temp_display"
+                                size="lg" show_target="true" bind_current="bed_temp" bind_target="bed_target"
+                                event_cb="on_temp_graph_custom_clicked"/>
+                </lv_obj>
+                <text_small name="bed_status_msg" bind_text="bed_status" style_text_align="left"/>
               </lv_obj>
-              <text_small name="bed_status_msg" bind_text="bed_status" style_text_align="left"/>
+              <lv_obj height="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
             </lv_obj>
-            <lv_obj height="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
+          </ui_card>
+          <lv_obj width="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
+          <lv_obj name="bed_preset_grid"
+                  width="100%" height="content" style_pad_all="0" scrollable="false" flex_flow="row_wrap"
+                  style_flex_main_place="space_between" style_pad_gap="#space_xs">
+            <ui_button name="bed_preset_off"
+                       width="48%" text="Off" translation_tag="Off" variant="ghost" style_border_width="#border_width"
+                       style_border_color="#border" style_border_opa="255">
+              <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+            </ui_button>
+            <ui_button name="bed_preset_1" width="48%" bind_text="preset_material_0_name">
+              <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+            </ui_button>
+            <ui_button name="bed_preset_2" width="48%" bind_text="preset_material_1_name">
+              <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+            </ui_button>
+            <ui_button name="bed_preset_3" width="48%" bind_text="preset_material_2_name">
+              <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+            </ui_button>
           </lv_obj>
-        </ui_card>
-        <lv_obj width="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
-        <lv_obj name="bed_preset_grid"
-                width="100%" height="content" style_pad_all="0" scrollable="false" flex_flow="row_wrap"
-                style_flex_main_place="space_between" style_pad_gap="#space_xs">
-          <ui_button name="bed_preset_off"
-                     width="48%" text="Off" translation_tag="Off" variant="ghost" style_border_width="#border_width"
-                     style_border_color="#border" style_border_opa="255">
-            <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+          <ui_button name="bed_btn_custom" width="100%" text="Custom..." translation_tag="Custom..." variant="secondary">
+            <event_cb trigger="clicked" callback="on_temp_graph_custom_clicked"/>
           </ui_button>
-          <ui_button name="bed_preset_1" width="48%" bind_text="preset_material_0_name">
-            <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
-          </ui_button>
-          <ui_button name="bed_preset_2" width="48%" bind_text="preset_material_1_name">
-            <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
-          </ui_button>
-          <ui_button name="bed_preset_3" width="48%" bind_text="preset_material_2_name">
-            <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
-          </ui_button>
-        </lv_obj>
-        <ui_button name="bed_btn_custom" width="100%" text="Custom..." translation_tag="Custom..." variant="secondary">
-          <event_cb trigger="clicked" callback="on_temp_graph_custom_clicked"/>
-        </ui_button>
+          <else/>
+          <!-- PORTRAIT: compact card | right column. Card is wrapped in a
+               full-height column container that centers it vertically (see
+               nozzle strip comment for rationale). -->
+          <lv_obj height="100%" width="content" flex_flow="column"
+                  style_flex_main_place="center" style_pad_all="0"
+                  scrollable="false" style_border_opa="0">
+            <ui_card name="bed_display_card"
+                     width="content" height="content" style_radius="0" flex_flow="column"
+                     style_flex_main_place="center" style_flex_cross_place="center"
+                     style_pad_gap="#space_xs" style_pad_all="#space_sm">
+              <heater_icon src="radiator" glyph_name="bed_icon_glyph" size="md"/>
+              <temp_display name="bed_temp_display"
+                            size="md" show_target="true" bind_current="bed_temp" bind_target="bed_target"
+                            event_cb="on_temp_graph_custom_clicked"/>
+              <text_small name="bed_status_msg" bind_text="bed_status" style_text_align="center"/>
+            </ui_card>
+          </lv_obj>
+          <lv_obj flex_grow="1" height="content" flex_flow="column"
+                  style_pad_all="0" style_pad_gap="#space_sm" scrollable="false" style_border_opa="0">
+            <lv_obj name="bed_preset_grid"
+                    width="100%" height="content" style_pad_all="0" scrollable="false" flex_flow="row_wrap"
+                    style_flex_main_place="space_between" style_pad_gap="#space_xs">
+              <ui_button name="bed_preset_off"
+                         width="48%" text="Off" translation_tag="Off" variant="ghost" style_border_width="#border_width"
+                         style_border_color="#border" style_border_opa="255">
+                <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+              </ui_button>
+              <ui_button name="bed_preset_1" width="48%" bind_text="preset_material_0_name">
+                <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+              </ui_button>
+              <ui_button name="bed_preset_2" width="48%" bind_text="preset_material_1_name">
+                <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+              </ui_button>
+              <ui_button name="bed_preset_3" width="48%" bind_text="preset_material_2_name">
+                <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+              </ui_button>
+            </lv_obj>
+            <ui_button name="bed_btn_custom" width="100%" text="Custom..." translation_tag="Custom..." variant="secondary">
+              <event_cb trigger="clicked" callback="on_temp_graph_custom_clicked"/>
+            </ui_button>
+          </lv_obj>
+        </if>
       </lv_obj>
 
       <!-- ════════════════════════════════════════════════════════════════ -->
       <!-- Right Column: CHAMBER controls (shown in chamber mode only)    -->
       <!-- ════════════════════════════════════════════════════════════════ -->
       <lv_obj name="chamber_control_strip"
-              style_pad_all="0" scrollable="false" style_border_opa="0" flex_flow="column" style_flex_main_place="start"
-              style_flex_cross_place="center" style_pad_gap="#space_sm" hidden="true">
+              style_pad_all="0" scrollable="false" style_border_opa="0"
+              style_pad_gap="#space_sm" hidden="true">
+        <bind_flag_if_not_eq subject="temp_graph_mode" flag="hidden" ref_value="3"/>
         <bind_style_if name="tg_strip_portrait" cond="ui_is_portrait"/>
         <bind_style_if name="tg_strip_landscape" cond="ui_is_portrait" invert="true"/>
-        <ui_card name="chamber_display_card"
-                 width="100%" height="content" style_radius="0" flex_flow="column" style_flex_main_place="center"
-                 style_pad_gap="#space_xs" style_pad_all="#space_sm">
-          <lv_obj width="100%" flex_flow="row" style_pad_all="0" scrollable="false">
-            <lv_obj height="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
-            <lv_obj height="content"
-                    flex_flow="column" style_flex_cross_place="start" style_pad_all="0" style_pad_gap="#space_xs"
-                    scrollable="false">
-              <heater_icon src="fridge_industrial" glyph_name="chamber_icon_glyph" size="xl"/>
-              <lv_obj style_pad_all="0"
-                      scrollable="false" flex_flow="column" style_flex_main_place="center"
-                      style_flex_cross_place="start" style_pad_gap="#space_xxs">
-                <text_small text="Current / Target" translation_tag="Current / Target"/>
-                <temp_display name="chamber_temp_display"
-                              size="lg" show_target="true" bind_current="chamber_temp"
-                              bind_target="chamber_effective_target" bind_mode="chamber_mode"/>
+
+        <if cond="ui_is_portrait eq 0">
+          <!-- LANDSCAPE -->
+          <ui_card name="chamber_display_card"
+                   width="100%" height="content" style_radius="0" flex_flow="column" style_flex_main_place="center"
+                   style_pad_gap="#space_xs" style_pad_all="#space_sm">
+            <lv_obj width="100%" flex_flow="row" style_pad_all="0" scrollable="false">
+              <lv_obj height="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
+              <lv_obj height="content"
+                      flex_flow="column" style_flex_cross_place="start" style_pad_all="0" style_pad_gap="#space_xs"
+                      scrollable="false">
+                <heater_icon src="fridge_industrial" glyph_name="chamber_icon_glyph" size="xl"/>
+                <lv_obj style_pad_all="0"
+                        scrollable="false" flex_flow="column" style_flex_main_place="center"
+                        style_flex_cross_place="start" style_pad_gap="#space_xxs">
+                  <text_small text="Current / Target" translation_tag="Current / Target"/>
+                  <temp_display name="chamber_temp_display"
+                                size="lg" show_target="true" bind_current="chamber_temp"
+                                bind_target="chamber_effective_target" bind_mode="chamber_mode"
+                                event_cb="on_temp_graph_custom_clicked"/>
+                </lv_obj>
+                <text_small name="chamber_status_msg" bind_text="chamber_status" style_text_align="left"/>
               </lv_obj>
-              <text_small name="chamber_status_msg" bind_text="chamber_status" style_text_align="left"/>
+              <lv_obj height="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
             </lv_obj>
-            <lv_obj height="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
+          </ui_card>
+          <lv_obj width="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
+          <!-- Preset buttons: hidden when chamber is sensor-only -->
+          <lv_obj name="chamber_preset_grid"
+                  width="100%" height="content" style_pad_all="0" scrollable="false" flex_flow="row_wrap"
+                  style_flex_main_place="space_between" style_pad_gap="#space_xs">
+            <bind_flag_if_eq subject="printer_has_chamber_heater" flag="hidden" ref_value="0"/>
+            <ui_button name="chamber_preset_off"
+                       width="48%" text="Off" translation_tag="Off" variant="ghost" style_border_width="#border_width"
+                       style_border_color="#border" style_border_opa="255">
+              <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+            </ui_button>
+            <ui_button name="chamber_preset_1" width="48%" text="40°C">
+              <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+            </ui_button>
+            <ui_button name="chamber_preset_2" width="48%" text="50°C">
+              <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+            </ui_button>
+            <ui_button name="chamber_preset_3" width="48%" text="60°C">
+              <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+            </ui_button>
           </lv_obj>
-        </ui_card>
-        <lv_obj width="1" flex_grow="1" style_pad_all="0" scrollable="false"/>
-        <!-- Preset buttons: hidden when chamber is sensor-only -->
-        <lv_obj name="chamber_preset_grid"
-                width="100%" height="content" style_pad_all="0" scrollable="false" flex_flow="row_wrap"
-                style_flex_main_place="space_between" style_pad_gap="#space_xs">
-          <bind_flag_if_eq subject="printer_has_chamber_heater" flag="hidden" ref_value="0"/>
-          <ui_button name="chamber_preset_off"
-                     width="48%" text="Off" translation_tag="Off" variant="ghost" style_border_width="#border_width"
-                     style_border_color="#border" style_border_opa="255">
-            <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+          <ui_button name="chamber_btn_custom"
+                     width="100%" text="Custom..." translation_tag="Custom..." variant="secondary">
+            <bind_flag_if_eq subject="printer_has_chamber_heater" flag="hidden" ref_value="0"/>
+            <event_cb trigger="clicked" callback="on_temp_graph_custom_clicked"/>
           </ui_button>
-          <ui_button name="chamber_preset_1" width="48%" text="40°C">
-            <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
-          </ui_button>
-          <ui_button name="chamber_preset_2" width="48%" text="50°C">
-            <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
-          </ui_button>
-          <ui_button name="chamber_preset_3" width="48%" text="60°C">
-            <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
-          </ui_button>
-        </lv_obj>
-        <ui_button name="chamber_btn_custom"
-                   width="100%" text="Custom..." translation_tag="Custom..." variant="secondary">
-          <bind_flag_if_eq subject="printer_has_chamber_heater" flag="hidden" ref_value="0"/>
-          <event_cb trigger="clicked" callback="on_temp_graph_custom_clicked"/>
-        </ui_button>
+          <else/>
+          <!-- PORTRAIT: compact card | right column. The chamber_has_heater
+               guard applies to the preset grid and Custom button in both
+               branches; a sensor-only chamber degrades to just the display
+               card on the left and an empty right column. Card is wrapped in
+               a full-height centering container (see nozzle strip comment). -->
+          <lv_obj height="100%" width="content" flex_flow="column"
+                  style_flex_main_place="center" style_pad_all="0"
+                  scrollable="false" style_border_opa="0">
+            <ui_card name="chamber_display_card"
+                     width="content" height="content" style_radius="0" flex_flow="column"
+                     style_flex_main_place="center" style_flex_cross_place="center"
+                     style_pad_gap="#space_xs" style_pad_all="#space_sm">
+              <heater_icon src="fridge_industrial" glyph_name="chamber_icon_glyph" size="md"/>
+              <temp_display name="chamber_temp_display"
+                            size="md" show_target="true" bind_current="chamber_temp"
+                            bind_target="chamber_effective_target" bind_mode="chamber_mode"
+                            event_cb="on_temp_graph_custom_clicked"/>
+              <text_small name="chamber_status_msg" bind_text="chamber_status" style_text_align="center"/>
+            </ui_card>
+          </lv_obj>
+          <lv_obj flex_grow="1" height="content" flex_flow="column"
+                  style_pad_all="0" style_pad_gap="#space_sm" scrollable="false" style_border_opa="0">
+            <lv_obj name="chamber_preset_grid"
+                    width="100%" height="content" style_pad_all="0" scrollable="false" flex_flow="row_wrap"
+                    style_flex_main_place="space_between" style_pad_gap="#space_xs">
+              <bind_flag_if_eq subject="printer_has_chamber_heater" flag="hidden" ref_value="0"/>
+              <ui_button name="chamber_preset_off"
+                         width="48%" text="Off" translation_tag="Off" variant="ghost" style_border_width="#border_width"
+                         style_border_color="#border" style_border_opa="255">
+                <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+              </ui_button>
+              <ui_button name="chamber_preset_1" width="48%" text="40°C">
+                <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+              </ui_button>
+              <ui_button name="chamber_preset_2" width="48%" text="50°C">
+                <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+              </ui_button>
+              <ui_button name="chamber_preset_3" width="48%" text="60°C">
+                <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
+              </ui_button>
+            </lv_obj>
+            <ui_button name="chamber_btn_custom"
+                       width="100%" text="Custom..." translation_tag="Custom..." variant="secondary">
+              <bind_flag_if_eq subject="printer_has_chamber_heater" flag="hidden" ref_value="0"/>
+              <event_cb trigger="clicked" callback="on_temp_graph_custom_clicked"/>
+            </ui_button>
+          </lv_obj>
+        </if>
       </lv_obj>
 
     </lv_obj>

--- a/ui_xml/temp_graph_overlay.xml
+++ b/ui_xml/temp_graph_overlay.xml
@@ -44,10 +44,12 @@
     <!-- strip orientation axis. Carries layout=flex AND flex_flow because a
          style sets only what it names; the strip elements have no inline
          flex_flow (inline would override the bind per AGENTS.md rule 6). -->
-    <style name="tg_strip_landscape" layout="flex" flex_flow="column" width="33%" height="100%"
-           style_flex_main_place="start" style_flex_cross_place="center"/>
-    <style name="tg_strip_portrait" layout="flex" flex_flow="row" width="100%" height="content"
-           style_flex_main_place="start" style_flex_cross_place="center"/>
+    <style name="tg_strip_landscape"
+           width="33%" height="100%" layout="flex" flex_flow="column" style_flex_main_place="start"
+           style_flex_cross_place="center"/>
+    <style name="tg_strip_portrait"
+           width="100%" height="content" layout="flex" flex_flow="row" style_flex_main_place="start"
+           style_flex_cross_place="center"/>
   </styles>
   <view name="temp_graph_overlay" extends="overlay_panel" title="Temperature" title_tag="Temperature">
     <!-- Content area: graph+chips left, controls right (side-by-side) -->
@@ -85,8 +87,7 @@
       <!-- Right Column: NOZZLE controls (shown in nozzle mode only)      -->
       <!-- ════════════════════════════════════════════════════════════════ -->
       <lv_obj name="nozzle_control_strip"
-              style_pad_all="0" scrollable="false" style_border_opa="0"
-              style_pad_gap="#space_sm" hidden="true">
+              style_pad_all="0" scrollable="false" style_border_opa="0" style_pad_gap="#space_sm" hidden="true">
         <!-- Show only in Nozzle mode (temp_graph_mode == 1). bind_flag_if_not_eq
              adds `hidden` when the condition is met (mode != 1) and removes it
              otherwise — so the inline hidden="true" is just the initial state
@@ -133,8 +134,8 @@
           </ui_card>
           <!-- Extruder selector (shown when multiple extruders detected) -->
           <lv_obj name="extruder_selector_row"
-                  width="100%" height="content" style_pad_all="0" scrollable="false" style_border_opa="0" flex_flow="row"
-                  style_pad_gap="#space_xs" style_flex_main_place="center" hidden="true">
+                  width="100%" height="content" style_pad_all="0" scrollable="false" style_border_opa="0"
+                  flex_flow="row" style_pad_gap="#space_xs" style_flex_main_place="center" hidden="true">
             <!-- Populated programmatically in C++ -->
           </lv_obj>
           <!-- Spacer -->
@@ -173,13 +174,12 @@
                content-height items, so we wrap explicitly. The right column
                holds the extruder selector, preset grid (still 2×2 but at
                narrower width), and Custom button. -->
-          <lv_obj height="100%" width="content" flex_flow="column"
-                  style_flex_main_place="center" style_pad_all="0"
-                  scrollable="false" style_border_opa="0">
+          <lv_obj width="content"
+                  height="100%" flex_flow="column" style_flex_main_place="center" style_pad_all="0" scrollable="false"
+                  style_border_opa="0">
             <ui_card name="nozzle_display_card"
-                     width="content" height="content" style_radius="0" flex_flow="column"
-                     style_flex_main_place="center" style_flex_cross_place="center"
-                     style_pad_gap="#space_xs" style_pad_all="#space_sm">
+                     width="content" height="content" style_radius="0" flex_flow="column" style_flex_main_place="center"
+                     style_flex_cross_place="center" style_pad_gap="#space_xs" style_pad_all="#space_sm">
               <nozzle_icon name="nozzle_heater_icon" size="md"/>
               <temp_display name="nozzle_temp_display"
                             size="md" show_target="true" bind_current="extruder_temp" bind_target="extruder_target"
@@ -188,11 +188,12 @@
                           style_border_width="0" bind_text="nozzle_status" style_text_align="center"/>
             </ui_card>
           </lv_obj>
-          <lv_obj flex_grow="1" height="content" flex_flow="column"
-                  style_pad_all="0" style_pad_gap="#space_sm" scrollable="false" style_border_opa="0">
+          <lv_obj height="content"
+                  flex_grow="1" flex_flow="column" style_pad_all="0" style_pad_gap="#space_sm" scrollable="false"
+                  style_border_opa="0">
             <lv_obj name="extruder_selector_row"
-                    width="100%" height="content" style_pad_all="0" scrollable="false" style_border_opa="0" flex_flow="row"
-                    style_pad_gap="#space_xs" style_flex_main_place="center" hidden="true">
+                    width="100%" height="content" style_pad_all="0" scrollable="false" style_border_opa="0"
+                    flex_flow="row" style_pad_gap="#space_xs" style_flex_main_place="center" hidden="true">
               <!-- Populated programmatically in C++ -->
             </lv_obj>
             <lv_obj name="nozzle_preset_grid"
@@ -225,8 +226,7 @@
       <!-- Right Column: BED controls (shown in bed mode only)            -->
       <!-- ════════════════════════════════════════════════════════════════ -->
       <lv_obj name="bed_control_strip"
-              style_pad_all="0" scrollable="false" style_border_opa="0"
-              style_pad_gap="#space_sm" hidden="true">
+              style_pad_all="0" scrollable="false" style_border_opa="0" style_pad_gap="#space_sm" hidden="true">
         <bind_flag_if_not_eq subject="temp_graph_mode" flag="hidden" ref_value="2"/>
         <bind_style_if name="tg_strip_portrait" cond="ui_is_portrait"/>
         <bind_style_if name="tg_strip_landscape" cond="ui_is_portrait" invert="true"/>
@@ -281,13 +281,12 @@
           <!-- PORTRAIT: compact card | right column. Card is wrapped in a
                full-height column container that centers it vertically (see
                nozzle strip comment for rationale). -->
-          <lv_obj height="100%" width="content" flex_flow="column"
-                  style_flex_main_place="center" style_pad_all="0"
-                  scrollable="false" style_border_opa="0">
+          <lv_obj width="content"
+                  height="100%" flex_flow="column" style_flex_main_place="center" style_pad_all="0" scrollable="false"
+                  style_border_opa="0">
             <ui_card name="bed_display_card"
-                     width="content" height="content" style_radius="0" flex_flow="column"
-                     style_flex_main_place="center" style_flex_cross_place="center"
-                     style_pad_gap="#space_xs" style_pad_all="#space_sm">
+                     width="content" height="content" style_radius="0" flex_flow="column" style_flex_main_place="center"
+                     style_flex_cross_place="center" style_pad_gap="#space_xs" style_pad_all="#space_sm">
               <heater_icon src="radiator" glyph_name="bed_icon_glyph" size="md"/>
               <temp_display name="bed_temp_display"
                             size="md" show_target="true" bind_current="bed_temp" bind_target="bed_target"
@@ -295,8 +294,9 @@
               <text_small name="bed_status_msg" bind_text="bed_status" style_text_align="center"/>
             </ui_card>
           </lv_obj>
-          <lv_obj flex_grow="1" height="content" flex_flow="column"
-                  style_pad_all="0" style_pad_gap="#space_sm" scrollable="false" style_border_opa="0">
+          <lv_obj height="content"
+                  flex_grow="1" flex_flow="column" style_pad_all="0" style_pad_gap="#space_sm" scrollable="false"
+                  style_border_opa="0">
             <lv_obj name="bed_preset_grid"
                     width="100%" height="content" style_pad_all="0" scrollable="false" flex_flow="row_wrap"
                     style_flex_main_place="space_between" style_pad_gap="#space_xs">
@@ -315,7 +315,8 @@
                 <event_cb trigger="clicked" callback="on_temp_graph_preset_clicked"/>
               </ui_button>
             </lv_obj>
-            <ui_button name="bed_btn_custom" width="100%" text="Custom..." translation_tag="Custom..." variant="secondary">
+            <ui_button name="bed_btn_custom"
+                       width="100%" text="Custom..." translation_tag="Custom..." variant="secondary">
               <event_cb trigger="clicked" callback="on_temp_graph_custom_clicked"/>
             </ui_button>
           </lv_obj>
@@ -326,8 +327,7 @@
       <!-- Right Column: CHAMBER controls (shown in chamber mode only)    -->
       <!-- ════════════════════════════════════════════════════════════════ -->
       <lv_obj name="chamber_control_strip"
-              style_pad_all="0" scrollable="false" style_border_opa="0"
-              style_pad_gap="#space_sm" hidden="true">
+              style_pad_all="0" scrollable="false" style_border_opa="0" style_pad_gap="#space_sm" hidden="true">
         <bind_flag_if_not_eq subject="temp_graph_mode" flag="hidden" ref_value="3"/>
         <bind_style_if name="tg_strip_portrait" cond="ui_is_portrait"/>
         <bind_style_if name="tg_strip_landscape" cond="ui_is_portrait" invert="true"/>
@@ -389,13 +389,12 @@
                branches; a sensor-only chamber degrades to just the display
                card on the left and an empty right column. Card is wrapped in
                a full-height centering container (see nozzle strip comment). -->
-          <lv_obj height="100%" width="content" flex_flow="column"
-                  style_flex_main_place="center" style_pad_all="0"
-                  scrollable="false" style_border_opa="0">
+          <lv_obj width="content"
+                  height="100%" flex_flow="column" style_flex_main_place="center" style_pad_all="0" scrollable="false"
+                  style_border_opa="0">
             <ui_card name="chamber_display_card"
-                     width="content" height="content" style_radius="0" flex_flow="column"
-                     style_flex_main_place="center" style_flex_cross_place="center"
-                     style_pad_gap="#space_xs" style_pad_all="#space_sm">
+                     width="content" height="content" style_radius="0" flex_flow="column" style_flex_main_place="center"
+                     style_flex_cross_place="center" style_pad_gap="#space_xs" style_pad_all="#space_sm">
               <heater_icon src="fridge_industrial" glyph_name="chamber_icon_glyph" size="md"/>
               <temp_display name="chamber_temp_display"
                             size="md" show_target="true" bind_current="chamber_temp"
@@ -404,8 +403,9 @@
               <text_small name="chamber_status_msg" bind_text="chamber_status" style_text_align="center"/>
             </ui_card>
           </lv_obj>
-          <lv_obj flex_grow="1" height="content" flex_flow="column"
-                  style_pad_all="0" style_pad_gap="#space_sm" scrollable="false" style_border_opa="0">
+          <lv_obj height="content"
+                  flex_grow="1" flex_flow="column" style_pad_all="0" style_pad_gap="#space_sm" scrollable="false"
+                  style_border_opa="0">
             <lv_obj name="chamber_preset_grid"
                     width="100%" height="content" style_pad_all="0" scrollable="false" flex_flow="row_wrap"
                     style_flex_main_place="space_between" style_pad_gap="#space_xs">


### PR DESCRIPTION
Follow-up to #1252. Finishes the declarative conversion that patch started and tightens the portrait outcome.

## What changed

**Strip visibility and graph width move from C++ to XML, driven by a new `temp_graph_mode` int subject (0=GraphOnly, 1=Nozzle, 2=Bed, 3=Chamber) set by `TempGraphOverlay::open()`.**

- Strip visibility: `bind_flag_if_not_eq subject="temp_graph_mode" flag="hidden" ref_value="N"` per strip — the C++ hide-all/show-active loop in `configure_control_strip()` is gone.
- Graph width: `bind_style_if` pair with inline `cond="ui_is_portrait or temp_graph_mode eq 0"`. Inline `cond=` rather than `<subject_expr>` because `<subject_expr>` evaluates at component-load time (Phase 8c), before `init_subjects()` (Phase 9a) registers the subject — inline `cond=` on `bind_style_if` compiles at view creation, after init. First production use of compound `cond=` on `bind_style_if` (`calibration_pid_panel.xml:51` uses compound cond on `action_button_disabled_cond`; `bed_mesh_current_mesh_card.xml:32` ships `<subject_expr>` with the same grammar).
- Orthogonal style axes: graph_outer carries one width-axis pair (mode-driven) and one container-axis pair (orientation-driven). No 4-state cross-product.

**Portrait strip layout, via `<if cond="ui_is_portrait eq 0">` per strip.** Landscape body is unchanged. Portrait body is a row: compact card (`size="md"` icon + temp + status, content-width, wrapped in a full-height centering container) on the left, preset grid + Custom in a right-column wrapper. LVGL flex `cross_place` on the strip doesn't reliably center content-height items, so the wrapper is explicit.

**`temp_display` gains `event_cb="on_temp_graph_custom_clicked"`** so tapping the card opens the keypad in either orientation (was wired only on the Custom button).

**Drops** `layout_manager.h` include and the now-unused `graph_outer_` member.

## Why

The merged portrait patch (#1252) carried C++ that fought its own bound styles — `configure_control_strip()` imperatively wrote graph widths that overrode the `bind_style_if` pair it had just added. That was the existing print_status seam (`LayoutManager::instance().type()`), defensible as consistency but leaving the mode dimension in C++. This PR finishes the conversion.

The portrait strip layout was also eating the graph: the landscape-oriented `nozzle_display_card` (`size="xl"` icon, ~140px tall) plus a 2×2 preset grid plus Custom claimed 267px of the 338px content area on 272×480, leaving a 36px graph plot. Option 3 from the review discussion: horizontal split — compact card on the left, controls on the right.

## Verification (ctl geom)

| Size | graph plot | strip h | card w×h | grid w×h |
|---|---|---|---|---|
| Landscape 800×480 | 446×398 | 398 | 223×173 (xl, unchanged) | 223×109 |
| Portrait 272×480 | **256×162** (was 36) | 162 (was 267) | 69×70 (md) | 183×106 |
| Portrait 480×800 | **448×316** (was 129) | 252 (was 439) | 105×105 (md) | 336×165 |

Card vertically centered against the taller right column (verified via `ctl geom` y-coords: card center y = strip center y).

Tests: `[temperature],[layout],[xml],[theme],[modal]` green (422 cases, 9833 assertions). `[action_prompt]` has the same single pre-existing failure as clean main (census mismatch in `action_prompt-stress`).

Gates: imperative-UI 387 → 384 (the 3 strip-visibility `add_flag(HIDDEN)` calls removed). Duplicate-XML-name gate clean (`<if>`/`<else>` branch pairs skipped by design). Quality-checks.sh clean. clang-format + XML format-hooks clean.

## Out of scope

- `#1255` (unify `ui_is_portrait` with `LayoutManager::type()`) — filed separately. Once that lands, the inline `cond="ui_is_portrait or temp_graph_mode eq 0"` continues to work; the C++ side of this overlay no longer reads `LayoutManager::type()` at all after this PR, so the override-divergence concern from #1252 review is already resolved here.
- Extracting the preset buttons + Custom into a parameterized component to dedupe the ~150 lines of XML added across the three `<if>` branches. Sketch in the review thread; recommend as follow-up only if the portrait layout sticks.