### PR TITLE
fix(notifications): live-refresh the open history panel (prestonbrown/helixscreen#1525)

### DIFF
--- a/include/ui_notification_history.h
+++ b/include/ui_notification_history.h
@@ -94,6 +94,18 @@ class NotificationHistory {
     size_t count() const;
 
     /**
+     * @brief Get the history revision
+     *
+     * Increments on every add() and clear(). mark_all_read() does not bump it,
+     * so a consumer that refreshes on revision change cannot loop itself
+     * (refresh marks the entries read). Used by the notification panel to
+     * rebuild its list when a notification arrives while it is open.
+     *
+     * @return Monotonic revision counter
+     */
+    uint64_t version() const;
+
+    /**
      * @brief Seed test notifications for --test mode debugging
      *
      * Adds a variety of test notifications with different severities
@@ -111,4 +123,5 @@ class NotificationHistory {
     std::vector<NotificationHistoryEntry> entries_;
     size_t head_index_ = 0;    ///< Circular buffer write position
     bool buffer_full_ = false; ///< True when we've wrapped around
+    uint64_t version_ = 0;     ///< Bumped on add()/clear(), never on mark_all_read()
 };

--- a/include/ui_notification_manager.h
+++ b/include/ui_notification_manager.h
@@ -60,6 +60,7 @@ class NotificationManager {
      * - notification_count (int: badge count, 0=hidden)
      * - notification_count_text (string: formatted count)
      * - notification_severity (int: 0=info, 1=warning, 2=error)
+     * - notification_history_version (int: history revision, bumped on add/clear)
      */
     void init_subjects();
 
@@ -81,6 +82,22 @@ class NotificationManager {
      * @param count Number of unread notifications (0 hides badge)
      */
     void update_notification_count(size_t count);
+
+    /**
+     * @brief Publish the history revision to the version subject
+     *
+     * Compares NotificationHistory::version() against the last published value
+     * and sets notification_history_version only on a change. Must be called
+     * on the LVGL main thread; notification_refresh_from_history() does that.
+     */
+    void publish_history_version();
+
+    /**
+     * @brief Get the history version subject for observer attachment
+     *
+     * @return Subject pointer, or nullptr before init_subjects()
+     */
+    lv_subject_t* history_version_subject();
 
     /**
      * @brief Deinitialize subjects for clean shutdown
@@ -116,6 +133,7 @@ class NotificationManager {
     lv_subject_t notification_count_subject_{};
     lv_subject_t notification_count_text_subject_{};
     lv_subject_t notification_severity_subject_{}; // 0=info, 1=warning, 2=error
+    lv_subject_t notification_history_version_subject_{};
 
     // Notification count text buffer (for string subject)
     char notification_count_text_buf_[8] = "0";
@@ -125,6 +143,9 @@ class NotificationManager {
 
     // Track previous notification count for pulse animation (only pulse on increase)
     size_t previous_notification_count_ = 0;
+
+    // Last history revision published to notification_history_version
+    uint64_t last_published_history_version_ = 0;
 
     bool subjects_initialized_ = false;
     bool callbacks_registered_ = false;
@@ -177,5 +198,12 @@ void notification_update_count(size_t count);
  * (ERROR > WARNING > INFO; NONE when nothing is unread) to the badge color.
  */
 void notification_refresh_from_history();
+
+/**
+ * @brief Get the subject that fires when the history revision changes
+ *
+ * @return Subject pointer, or nullptr before notification_init_subjects()
+ */
+lv_subject_t* notification_history_version_subject();
 
 } // namespace helix::ui

--- a/include/ui_panel_notification_history.h
+++ b/include/ui_panel_notification_history.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "ui_notification_history.h"
+#include "ui_observer_guard.h"
 #include "ui_panel_base.h"
 
 #include "subject_managed_panel.h"
@@ -89,8 +90,8 @@ class NotificationHistoryPanel : public PanelBase {
     /**
      * @brief Refresh the notification list
      *
-     * Called when panel is shown or after clear.
-     * Rebuilds the list from NotificationHistory service.
+     * Rebuilds the list from NotificationHistory service. Called when the panel
+     * is shown, after clear, and whenever the history revision subject changes.
      */
     void refresh();
 
@@ -111,6 +112,15 @@ class NotificationHistoryPanel : public PanelBase {
     /// Has entries subject (1 = has entries, 0 = empty)
     lv_subject_t has_entries_subject_;
 
+    /// Fires refresh() when a notification arrives while the panel is open.
+    /// No paired SubjectLifetime: the subject belongs to the NotificationManager
+    /// singletons, which outlive the panel (and this observer is reset in
+    /// deinit_subjects() while the subject is still live).
+    ObserverGuard history_version_observer_;
+
+    /// Last revision applied by the observer (0 = none; subject values start at 1).
+    int32_t last_applied_history_version_ = 0;
+
     //
     // === Private Helpers ===
     //
@@ -130,6 +140,15 @@ class NotificationHistoryPanel : public PanelBase {
     //
 
     void handle_clear_clicked();
+
+    /**
+     * @brief Handle a history revision change observed from NotificationManager
+     *
+     * Skips revisions already applied (refresh marks entries read without
+     * bumping the revision, but double-publishes can arrive) and rebuilds
+     * the list from the store.
+     */
+    void handle_history_version_change(int32_t version);
 
     //
     // === Per-item click context ===

--- a/src/ui/ui_notification_history.cpp
+++ b/src/ui/ui_notification_history.cpp
@@ -35,6 +35,8 @@ void NotificationHistory::add(const NotificationHistoryEntry& entry) {
         head_index_ = (head_index_ + 1) % MAX_ENTRIES;
     }
 
+    ++version_;
+
     spdlog::trace("[Notification History] Added notification to history: severity={}, message='{}'",
                   static_cast<int>(entry.severity), entry.message);
 }
@@ -126,6 +128,7 @@ void NotificationHistory::clear() {
     entries_.clear();
     head_index_ = 0;
     buffer_full_ = false;
+    ++version_;
 
     spdlog::debug("[Notification History] Cleared notification history");
 }
@@ -133,6 +136,11 @@ void NotificationHistory::clear() {
 size_t NotificationHistory::count() const {
     std::lock_guard<std::mutex> lock(mutex_);
     return entries_.size();
+}
+
+uint64_t NotificationHistory::version() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return version_;
 }
 
 void NotificationHistory::seed_test_data() {

--- a/src/ui/ui_notification_manager.cpp
+++ b/src/ui/ui_notification_manager.cpp
@@ -120,6 +120,8 @@ void NotificationManager::init_subjects() {
                                "notification_count_text", subjects_);
     UI_MANAGED_SUBJECT_INT(notification_severity_subject_, NOTIFICATION_SEVERITY_INFO,
                            "notification_severity", subjects_);
+    UI_MANAGED_SUBJECT_INT(notification_history_version_subject_, 0, "notification_history_version",
+                           subjects_);
 
     subjects_initialized_ = true;
 
@@ -296,6 +298,30 @@ void helix::ui::notification_refresh_from_history() {
         }
     }
     NotificationManager::instance().update_notification(status);
+
+    // Publish the history revision so the open notification panel can rebuild
+    // its list when an entry arrives (prestonbrown/helixscreen#1525).
+    NotificationManager::instance().publish_history_version();
+}
+
+void NotificationManager::publish_history_version() {
+    if (!subjects_initialized_) {
+        return;
+    }
+    uint64_t version = NotificationHistory::instance().version();
+    if (version == last_published_history_version_) {
+        return;
+    }
+    last_published_history_version_ = version;
+    lv_subject_set_int(&notification_history_version_subject_, static_cast<int32_t>(version));
+}
+
+lv_subject_t* NotificationManager::history_version_subject() {
+    return subjects_initialized_ ? &notification_history_version_subject_ : nullptr;
+}
+
+lv_subject_t* helix::ui::notification_history_version_subject() {
+    return NotificationManager::instance().history_version_subject();
 }
 
 void helix::ui::notification_deinit_subjects() {

--- a/src/ui/ui_panel_notification_history.cpp
+++ b/src/ui/ui_panel_notification_history.cpp
@@ -14,6 +14,7 @@
 
 #include "app_globals.h"
 #include "lvgl/src/others/translation/lv_translation.h"
+#include "observer_factory.h"
 #include "printer_state.h"
 #include "static_panel_registry.h"
 #include "system/update_checker.h"
@@ -61,6 +62,7 @@ void NotificationHistoryPanel::deinit_subjects() {
     if (!subjects_initialized_) {
         return;
     }
+    history_version_observer_.reset();
     subjects_.deinit_all();
     subjects_initialized_ = false;
     spdlog::debug("[{}] Subjects deinitialized", get_name());
@@ -85,6 +87,22 @@ void NotificationHistoryPanel::setup(lv_obj_t* panel, lv_obj_t* parent_screen) {
     // Hide Clear All button when there are no notifications
     if (action_btn) {
         lv_obj_bind_flag_if_eq(action_btn, &has_entries_subject_, LV_OBJ_FLAG_HIDDEN, 0);
+    }
+
+    // Refresh the list when a notification arrives while the panel is open.
+    // The observer attaches at most once per panel lifetime — setup() runs
+    // again on every reopen, and the subject is owned by the manager singleton
+    // that outlives this panel.
+    if (!history_version_observer_) {
+        lv_subject_t* version_subject = helix::ui::notification_history_version_subject();
+        if (version_subject) {
+            history_version_observer_ = helix::ui::observe_int_sync<NotificationHistoryPanel>(
+                version_subject, this, [](NotificationHistoryPanel* p, int value) {
+                    p->handle_history_version_change(value);
+                });
+        } else {
+            spdlog::warn("[{}] Notification history version subject not initialized", get_name());
+        }
     }
 
     // Populate list
@@ -208,8 +226,20 @@ std::string NotificationHistoryPanel::format_timestamp(uint64_t timestamp_ms) {
 // BUTTON HANDLERS
 // ============================================================================
 
+void NotificationHistoryPanel::handle_history_version_change(int32_t version) {
+    if (version == last_applied_history_version_) {
+        return;
+    }
+    last_applied_history_version_ = version;
+    refresh();
+}
+
 void NotificationHistoryPanel::handle_clear_clicked() {
     history_.clear();
+    // clear() bumps the store revision; the manager publishes it on its next
+    // badge refresh. Record it now so that publish does not rebuild the list
+    // again once it lands.
+    last_applied_history_version_ = static_cast<int32_t>(history_.version());
     refresh();
     spdlog::info("[{}] History cleared by user", get_name());
 }

--- a/tests/ui_test_utils.cpp
+++ b/tests/ui_test_utils.cpp
@@ -768,6 +768,7 @@ bool ToastManager::is_visible() const {
 
 // Stub for notification manager functions (tests don't have notification UI)
 #include "ui_notification.h"
+#include "ui_notification_history.h"
 #include "ui_notification_manager.h"
 #include "ui_printer_status_icon.h"
 
@@ -785,8 +786,22 @@ void ui_notification_deinit() {
     spdlog::debug("[Test Stub] ui_notification_deinit: no-op in tests");
 }
 
+static lv_subject_t s_test_notification_history_version_subject;
+static int32_t s_test_last_published_history_version = 0;
+static bool s_test_notification_subjects_initialized = false;
+
+// Mirrors NotificationManager::publish_history_version(): the real object is
+// out of the test link, but the panel's observer contract (bump revision on
+// add/clear, never on mark_all_read) is what the notification panel tests pin.
 void helix::ui::notification_refresh_from_history() {
-    // No-op in tests
+    if (!s_test_notification_subjects_initialized) {
+        return;
+    }
+    const int32_t narrowed = static_cast<int32_t>(NotificationHistory::instance().version());
+    if (narrowed != s_test_last_published_history_version) {
+        s_test_last_published_history_version = narrowed;
+        lv_subject_set_int(&s_test_notification_history_version_subject, narrowed);
+    }
 }
 
 // Stub for app_request_restart (tests don't restart)
@@ -1093,11 +1108,11 @@ lv_subject_t& get_wizard_active_subject() {
 
 // Stub for ui_notification_init_subjects (creates test subjects for notification badge)
 static lv_subject_t s_test_notification_count_subject;
-static bool s_test_notification_subjects_initialized = false;
 
 void helix::ui::notification_init_subjects() {
     if (!s_test_notification_subjects_initialized) {
         lv_subject_init_int(&s_test_notification_count_subject, 0);
+        lv_subject_init_int(&s_test_notification_history_version_subject, 0);
         s_test_notification_subjects_initialized = true;
         spdlog::debug("[Test Stub] ui_notification_init_subjects: subjects initialized");
     }
@@ -1106,9 +1121,14 @@ void helix::ui::notification_init_subjects() {
 void helix::ui::notification_deinit_subjects() {
     if (s_test_notification_subjects_initialized) {
         lv_subject_deinit(&s_test_notification_count_subject);
+        lv_subject_deinit(&s_test_notification_history_version_subject);
         s_test_notification_subjects_initialized = false;
         spdlog::debug("[Test Stub] ui_notification_deinit_subjects: subjects deinitialized");
     }
+}
+
+lv_subject_t* helix::ui::notification_history_version_subject() {
+    return &s_test_notification_history_version_subject;
 }
 
 void helix::ui::notification_register_callbacks() {

--- a/tests/unit/test_notification_history.cpp
+++ b/tests/unit/test_notification_history.cpp
@@ -397,3 +397,34 @@ TEST_CASE("NotificationHistory: Empty action field by default", "[ui][action]") 
     REQUIRE(entries.size() == 1);
     REQUIRE(entries[0].action[0] == '\0');
 }
+
+// ============================================================================
+// Revision counter (prestonbrown/helixscreen#1525)
+// ============================================================================
+
+TEST_CASE("NotificationHistory: version increments on add and clear", "[ui][version]") {
+    NotificationHistory& history = NotificationHistory::instance();
+    history.clear();
+
+    uint64_t base = history.version();
+    history.add(make_entry(ToastSeverity::INFO, "first"));
+    REQUIRE(history.version() == base + 1);
+
+    history.add(make_entry(ToastSeverity::WARNING, "second"));
+    base = history.version();
+    history.clear();
+    REQUIRE(history.version() == base + 1);
+    REQUIRE(history.count() == 0);
+}
+
+TEST_CASE("NotificationHistory: mark_all_read does not bump the version", "[ui][version]") {
+    // The panel refreshes on revision change and its refresh marks everything
+    // read — a read-only operation must not re-trigger the observer.
+    NotificationHistory& history = NotificationHistory::instance();
+    history.clear();
+    history.add(make_entry(ToastSeverity::INFO, "unread"));
+
+    uint64_t before = history.version();
+    history.mark_all_read();
+    REQUIRE(history.version() == before);
+}

--- a/tests/unit/test_notification_history_panel_refresh.cpp
+++ b/tests/unit/test_notification_history_panel_refresh.cpp
@@ -1,0 +1,154 @@
+// Copyright (C) 2025-2026 356C LLC
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_notification_history_panel_refresh.cpp
+ * @brief The open notification panel must show notifications that arrive while
+ *        it is visible (prestonbrown/helixscreen#1525).
+ *
+ * The list was a one-shot snapshot built when the overlay opened. The store
+ * fired nothing on add(), so a notification arriving while the panel was open
+ * incremented the bell badge while the list underneath stayed stale until a
+ * close-and-reopen destroyed and recreated the whole XML component.
+ *
+ * The seam this pins: NotificationHistory keeps a revision counter bumped on
+ * add()/clear(), NotificationManager publishes it into the
+ * notification_history_version subject whenever the badge refreshes, and the
+ * panel observes that subject and rebuilds its list. Killing either half of
+ * that chain fails the arrival test below.
+ */
+
+#include "ui_notification_history.h"
+#include "ui_notification_manager.h"
+#include "ui_panel_notification_history.h"
+#include "ui_update_queue.h"
+
+#include "../lvgl_ui_test_fixture.h"
+#include "helix-xml/src/xml/lv_xml.h"
+#include "printer_state.h"
+
+#include <cstring>
+#include <memory>
+
+#include "../catch_amalgamated.hpp"
+
+using helix::ui::UpdateQueue;
+
+namespace {
+
+NotificationHistoryEntry make_entry(const char* title, const char* message) {
+    NotificationHistoryEntry entry = {};
+    entry.timestamp_ms = lv_tick_get();
+    entry.severity = ToastSeverity::INFO;
+    entry.was_modal = false;
+    entry.was_read = false;
+    strncpy(entry.title, title, sizeof(entry.title) - 1);
+    strncpy(entry.message, message, sizeof(entry.message) - 1);
+    return entry;
+}
+
+/// Owns the NotificationHistoryPanel built from the production XML component.
+struct NotificationHistoryPanelFixture : public LVGLUITestFixture {
+    NotificationHistoryPanelFixture() {
+        helix::ui::notification_init_subjects();
+
+        auto& history = NotificationHistory::instance();
+        history.clear();
+
+        panel_ = std::make_unique<NotificationHistoryPanel>(state(), nullptr);
+        panel_->init_subjects();
+
+        // The panel resolves its severity_card / header_bar dependency chain
+        // through the production tree this fixture registers.
+        root_ = static_cast<lv_obj_t*>(
+            lv_xml_create(lv_screen_active(), "notification_history_panel", nullptr));
+        if (root_) {
+            panel_->setup(root_, lv_screen_active());
+        }
+    }
+
+    ~NotificationHistoryPanelFixture() override {
+        if (root_ && lv_obj_is_valid(root_)) {
+            lv_obj_delete(root_);
+        }
+        root_ = nullptr;
+        UpdateQueue::instance().drain();
+        panel_.reset();
+        UpdateQueue::instance().drain();
+    }
+
+    /// The live item container, or nullptr if the tree did not build.
+    lv_obj_t* content() const {
+        return root_ ? lv_obj_find_by_name(root_, "overlay_content") : nullptr;
+    }
+
+    std::unique_ptr<NotificationHistoryPanel> panel_;
+    lv_obj_t* root_ = nullptr;
+};
+
+} // namespace
+
+TEST_CASE_METHOD(NotificationHistoryPanelFixture,
+                 "NotificationHistoryPanel: arriving notification appears while the panel is open",
+                 "[ui][notifications][1525]") {
+    REQUIRE(root_ != nullptr);
+    lv_obj_t* overlay = content();
+    REQUIRE(overlay != nullptr);
+
+    NotificationHistory::instance().add(make_entry("Entry One", "before the panel opened"));
+    panel_->refresh();
+    REQUIRE(lv_obj_get_child_count(overlay) == 1);
+
+    // What production entry points do after writing the store.
+    NotificationHistory::instance().add(make_entry("Entry Two", "arrived while open"));
+    helix::ui::notification_refresh_from_history();
+    UpdateQueue::instance().drain();
+
+    REQUIRE(lv_obj_get_child_count(overlay) == 2);
+
+    // The list is newest-first, so the freshly arrived entry is the first item.
+    lv_obj_t* title = lv_obj_find_by_name(overlay, "item_title");
+    REQUIRE(title != nullptr);
+    REQUIRE(std::string(lv_label_get_text(title)) == "Entry Two");
+}
+
+TEST_CASE_METHOD(NotificationHistoryPanelFixture,
+                 "NotificationHistoryPanel: badge refresh without a new entry does not rebuild",
+                 "[ui][notifications][1525]") {
+    REQUIRE(root_ != nullptr);
+    lv_obj_t* overlay = content();
+    REQUIRE(overlay != nullptr);
+
+    NotificationHistory::instance().add(make_entry("Entry One", "only entry"));
+    panel_->refresh();
+    REQUIRE(lv_obj_get_child_count(overlay) == 1);
+
+    helix::ui::notification_refresh_from_history();
+    UpdateQueue::instance().drain();
+
+    REQUIRE(lv_obj_get_child_count(overlay) == 1);
+}
+
+TEST_CASE_METHOD(NotificationHistoryPanelFixture,
+                 "NotificationHistoryPanel: destroying the panel withdraws its version observer",
+                 "[ui][notifications][1525]") {
+    REQUIRE(root_ != nullptr);
+
+    lv_subject_t* subject = helix::ui::notification_history_version_subject();
+    REQUIRE(subject != nullptr);
+
+    // setup() attached exactly one observer on the manager's version subject.
+    REQUIRE(lv_ll_get_len(&subject->subs_ll) == 1);
+
+    // The observer defers through UpdateQueue; its removal must be immediate
+    // so a notification arriving after teardown queues nothing into freed
+    // state. Destroy in the same order as production: widgets first, then the
+    // panel (whose dtor runs deinit_subjects()).
+    lv_obj_delete(root_);
+    root_ = nullptr;
+    UpdateQueue::instance().drain();
+    panel_.reset();
+    UpdateQueue::instance().drain();
+
+    REQUIRE(lv_ll_get_len(&subject->subs_ll) == 0);
+}


### PR DESCRIPTION
NotificationHistory now keeps a revision counter (bumped by add/clear, never
mark_all_read, so a refresh-on-revision observer cannot loop itself).
NotificationManager publishes it into a new notification_history_version
subject from notification_refresh_from_history(), and the panel observes it
and rebuilds its list, so entries arriving while the overlay is open appear
without a close-and-reopen.

Tests: [1525] panel cases pin the arrival path (real XML tree + observer
chain) and the observer withdrawal on destroy; [ui][version] pins the store
counter. mutation: removing the panel's observer attach (ui_panel_notification_history.cpp#setup)
went red; removing the add()/clear() bump and the version() getter went red.
ui_notification_manager.{h,cpp} is out of the test link (mk/tests.mk Group 2),
so its publish hunks survive mutation by structure; the stub mirror in
tests/ui_test_utils.cpp drives the same contract the panel tests assert.
The deinit reset() hunk also survives (ObserverGuard's dtor is the second
line of defense); the reset matches ui_panel_ams convention.
