### PR TITLE
fix(logging): retire the LVGL log sink before spdlog dies (prestonbrown/helixscreen#1473)

### DIFF
--- a/include/lvgl_log_handler.h
+++ b/include/lvgl_log_handler.h
@@ -29,6 +29,17 @@ namespace logging {
 void register_lvgl_log_handler();
 
 /**
+ * @brief Retire the sink: subsequent LVGL logs are dropped without touching spdlog
+ *
+ * The sink's lifetime is anchored to the first registration, so its static
+ * destruction retires it while spdlog is still alive. Late LVGL log traffic
+ * during static teardown (lv_subject_deinit -> lv_observer_remove ->
+ * LV_LOG_WARN) is a no-op instead of a read into a freed logger. Callable
+ * explicitly by tests; register_lvgl_log_handler() re-arms it.
+ */
+void retire_lvgl_log_handler();
+
+/**
  * @brief Suppress LVGL translation warnings (downgrade to trace)
  *
  * When true, translation-related LVGL warnings (missing language, missing tag)

--- a/src/system/lvgl_log_handler.cpp
+++ b/src/system/lvgl_log_handler.cpp
@@ -282,6 +282,31 @@ void log_subject_debug_info(lv_subject_t* ptr) {
     }
 }
 
+/// True while the spdlog-routed sink is in service.
+///
+/// SubjectManager::deinit_all() runs during static destruction and calls
+/// lv_subject_deinit(), whose lv_observer_remove() emits LV_LOG_WARN for a
+/// null-subject observer. spdlog's registry is a lazily constructed
+/// function-local static, so it registers for destruction after load-time
+/// statics and is torn down BEFORE a static SubjectManager takes the full
+/// deinit path — a routed log there reads a freed logger. Zero-initialized
+/// before any dynamic initialization and never destroyed (trivially
+/// destructible), so it stays readable for the whole process; the retirement
+/// anchor below flips it off when the sink's own lifetime ends, which happens
+/// while spdlog is still alive because the anchor is constructed at
+/// registration, after the first spdlog use.
+static std::atomic<bool> s_sink_alive{false};
+
+/// Retired by its destructor when static teardown reaches it. Function-local
+/// so it is constructed at first registration — after spdlog's registry —
+/// and therefore destroyed before it: the window where the sink still routes
+/// into a dead logger never opens in the reverse order.
+struct SinkLifetimeAnchor {
+    ~SinkLifetimeAnchor() {
+        helix::logging::retire_lvgl_log_handler();
+    }
+};
+
 /**
  * @brief LVGL log callback that routes to spdlog
  *
@@ -292,6 +317,13 @@ void log_subject_debug_info(lv_subject_t* ptr) {
  * @param buf Log message buffer (null-terminated)
  */
 void lvgl_log_callback(lv_log_level_t level, const char* buf) {
+    // The sink is retired during static destruction: LVGL can still emit
+    // through it (lv_subject_deinit -> lv_observer_remove -> LV_LOG_WARN)
+    // after spdlog is gone, so drop the record rather than touch a freed
+    // logger.
+    if (!s_sink_alive.load(std::memory_order_acquire)) {
+        return;
+    }
     // Strip trailing newline if present (spdlog adds its own)
     std::string msg(buf);
     while (!msg.empty() && (msg.back() == '\n' || msg.back() == '\r')) {
@@ -440,8 +472,17 @@ namespace helix {
 namespace logging {
 
 void register_lvgl_log_handler() {
+    // Constructed at first registration, destroyed during static teardown —
+    // after spdlog's registry, so the retirement it performs still runs while
+    // the logger is alive.
+    static const SinkLifetimeAnchor anchor;
+    s_sink_alive.store(true, std::memory_order_release);
     lv_log_register_print_cb(lvgl_log_callback);
     spdlog::trace("[Logging] Registered custom LVGL log handler");
+}
+
+void retire_lvgl_log_handler() {
+    s_sink_alive.store(false, std::memory_order_release);
 }
 
 void set_suppress_translation_warnings(bool suppress) {

--- a/tests/unit/test_lvgl_log_repeat_dedupe.cpp
+++ b/tests/unit/test_lvgl_log_repeat_dedupe.cpp
@@ -199,3 +199,28 @@ TEST_CASE("LVGL log handler: init-time suppression does not spend a tag's one re
     warn_missing_tag(tag);
     CHECK(logs.in_ring(tag) == 1);
 }
+
+TEST_CASE("LVGL log handler: a retired sink drops LVGL traffic without touching spdlog",
+          "[logging][lvgl][1473]") {
+    helix::logging::register_lvgl_log_handler();
+    LevelCapture logs;
+
+    const std::string tag = unique_tag("retired");
+
+    // The probe reaches spdlog while the sink is armed.
+    warn_missing_tag(tag);
+    REQUIRE(logs.total(tag) == 1);
+
+    // Retired: the record is dropped inside the callback, before any spdlog
+    // call. During static destruction this is what keeps lv_subject_deinit's
+    // LV_LOG_WARN out of a freed logger.
+    helix::logging::retire_lvgl_log_handler();
+    warn_missing_tag(tag);
+    CHECK(logs.total(tag) == 1);
+
+    // Re-armed, the same message routes again (the dedupe class also keeps its
+    // first-occurrence entry from before the retirement, so this is a repeat).
+    helix::logging::register_lvgl_log_handler();
+    warn_missing_tag(tag);
+    CHECK(logs.total(tag) == 2);
+}


### PR DESCRIPTION
The only unfixed item from the port-pass review. Static SubjectManagers reach
deinit_all() -> lv_subject_deinit() -> lv_observer_remove() -> LV_LOG_WARN
after spdlog's registry is torn down, so the sink routed into a freed logger.
A file-scope liveness flag gates the callback; a function-local anchor
(constructed at first registration, after spdlog's first use, so destroyed
before the registry) retires the sink when static teardown reaches it.

Items 1-4a/c/d/e of the review are already fixed at origin/main (verified:
set_nonblocking failures propagate at all three sites, InflightGuard is
declared ahead of item, register_deinit replaces in place, the doc block and
the awk brace-depth gate are current).

Tests: [1473] pins retire -> drop -> re-arm against a real spdlog capture.
mutation: reverting the callback guard went red; flipping retire's store to
true by hand went red. The anchor/flag/register hunks read uncompilable
(reverting them breaks the build, so no test judged them).
