### PR TITLE
fix(ui): withdraw XML subject names when their owner is torn down (prestonbrown/helixscreen#1538)

### DIFF
--- a/include/subject_managed_panel.h
+++ b/include/subject_managed_panel.h
@@ -64,6 +64,7 @@
 #pragma once
 
 #include "helix/xml/scoped_subject_registry.h"
+#include "helix_lvgl_anomaly.h"
 #include "lvgl/lvgl.h"
 #include "subject_debug_registry.h"
 
@@ -162,13 +163,15 @@ class SubjectManager {
      * Safe to call multiple times - subsequent calls are no-ops.
      *
      * @note Checks lv_is_initialized() to handle static destruction order safely
-     * @note Never logs. A SubjectManager owned by a static reaches this through
-     *       the C++ atexit chain, and spdlog's registry - a lazily built
-     *       function-local static - is torn down before any object created
-     *       during dynamic initialization, so a log call here reads a freed
-     *       logger. An app that ran Application::shutdown() arrives with an
-     *       empty subjects_ and returns above; a binary that never does (every
-     *       unit test) takes the full path.
+     * @note Never calls spdlog (lint-enforced). A SubjectManager owned by a
+     *       static reaches this through the C++ atexit chain, and spdlog's
+     *       registry - a lazily built function-local static - is torn down
+     *       before any object created during dynamic initialization, so a log
+     *       call here reads a freed logger. The nameless-registration trap
+     *       below reports through helix_lvgl_anomaly (telemetry), which is
+     *       itself teardown-safe. An app that ran Application::shutdown()
+     *       arrives with an empty subjects_ and returns above; a binary that
+     *       never does (every unit test) takes the full path.
      * @note Each subject's XML-scope name is withdrawn before the subject is freed,
      *       so a name can never outlive the storage it resolves to. Owners that do
      *       not live for the whole process (a panel held by a stack-allocated test
@@ -203,8 +206,28 @@ class SubjectManager {
             // pointing at dead memory, and the next lv_xml_create() that binds
             // it reads freed storage. Unregistering turns that into a clean
             // "subject not found" instead.
-            if (i < subject_names_.size() && !subject_names_[i].empty()) {
-                helix::xml::unregister_subject_in_current_scope(subject_names_[i].c_str());
+            const char* registered_name = (i < subject_names_.size() && !subject_names_[i].empty())
+                                              ? subject_names_[i].c_str()
+                                              : nullptr;
+            if (registered_name) {
+                helix::xml::unregister_subject_in_current_scope(registered_name);
+            } else if (const SubjectDebugInfo* info =
+                           SubjectDebugRegistry::instance().lookup(subject)) {
+                // Registered without a name while the subject IS published
+                // under one (through a raw register or a macro elsewhere): the
+                // call site reads as RAII-correct, and the scope name would
+                // outlive this teardown. Withdraw it and make the trap loud
+                // via the anomaly channel — no logging can run here: this body
+                // reaches the C++ atexit chain, where spdlog may already be
+                // gone (and LV_LOG_* is banned in app code regardless).
+                helix_lvgl_anomaly("subject_manager_nameless_registered", info->name.c_str());
+                // Only withdraw when the name still resolves to THIS subject: a
+                // newer owner may have re-published the same name at a
+                // different address, and dropping that entry would strand its
+                // live bindings.
+                if (SubjectDebugRegistry::instance().lookup_by_name(info->name) == subject) {
+                    helix::xml::unregister_subject_in_current_scope(info->name.c_str());
+                }
             }
             // Same reasoning for the debug registry, which is also keyed by a
             // pointer that is about to dangle. Safe during static destruction:

--- a/include/ui_settings_barcode_scanner.h
+++ b/include/ui_settings_barcode_scanner.h
@@ -5,6 +5,7 @@
 #include "async_lifetime_guard.h"
 #include "input_device_scanner.h"
 #include "overlay_base.h"
+#include "subject_managed_panel.h"
 
 #include <atomic>
 #include <memory>
@@ -70,6 +71,7 @@ class BarcodeScannerSettingsOverlay : public OverlayBase {
     static void on_bs_bt_forget(lv_event_t* e);
 
     // Subjects (global scope — single-instance overlay)
+    SubjectManager subjects_; // declared ahead: tears down after the subjects it owns
     lv_subject_t bt_available_subject_{};
     lv_subject_t bt_discovering_subject_{};
     lv_subject_t keymap_index_subject_{};

--- a/include/ui_settings_display_sound.h
+++ b/include/ui_settings_display_sound.h
@@ -25,6 +25,7 @@
 
 #include "lvgl/lvgl.h"
 #include "overlay_base.h"
+#include "subject_managed_panel.h"
 #include "theme_loader.h"
 
 #include <string>
@@ -172,6 +173,10 @@ class DisplaySoundSettingsOverlay : public OverlayBase {
     std::string preview_theme_name_;
     /// Cached theme list (populated when explorer opens, avoids re-parsing on every toggle)
     std::vector<helix::ThemeInfo> cached_themes_;
+
+    /// SubjectManager, declared ahead of the subjects it owns so it tears down
+    /// after them (names withdraw before storage dies).
+    SubjectManager subjects_;
 
     /// Subject for brightness value label binding
     lv_subject_t brightness_value_subject_;

--- a/include/ui_settings_fans.h
+++ b/include/ui_settings_fans.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "overlay_base.h"
+#include "subject_managed_panel.h"
 
 #include <lvgl.h>
 #include <string>
@@ -95,6 +96,7 @@ class FanSettingsOverlay : public OverlayBase {
     // Rename modal state
     lv_obj_t* rename_modal_ = nullptr;
     std::string pending_rename_object_;
+    SubjectManager subjects_; // declared ahead: tears down after the subject it owns
     char rename_old_name_buf_[64] = {};
     lv_subject_t fan_rename_old_name_{}; ///< Subject for bind_text in modal
     bool rename_subject_initialized_ = false;

--- a/include/ui_settings_label_printer.h
+++ b/include/ui_settings_label_printer.h
@@ -7,6 +7,7 @@
 #include "lvgl/lvgl.h"
 #include "mdns_discovery.h"
 #include "overlay_base.h"
+#include "subject_managed_panel.h"
 #include "usb_printer_detector.h"
 
 #include <atomic>
@@ -87,6 +88,7 @@ class LabelPrinterSettingsOverlay : public OverlayBase {
     std::vector<DiscoveredPrinter> raw_printers_;        ///< temp buffer for raw TCP results
     std::vector<DiscoveredPrinter> ipp_printers_;        ///< temp buffer for IPP results
     std::vector<DiscoveredNetworkPrinter> discovered_network_printers_; ///< merged list
+    SubjectManager subjects_;             // declared ahead: tears down after the subjects it owns
     lv_subject_t ipp_selected_subject_{}; ///< 0=not IPP, 1=IPP protocol selected
 
     // USB printer detection

--- a/include/ui_settings_material_temps.h
+++ b/include/ui_settings_material_temps.h
@@ -5,6 +5,7 @@
 
 #include "lvgl/lvgl.h"
 #include "overlay_base.h"
+#include "subject_managed_panel.h"
 
 #include <string>
 
@@ -51,6 +52,10 @@ class MaterialTempsOverlay : public OverlayBase {
     void populate_material_list();
     void show_edit_view(const std::string& material_name);
     void show_list_view();
+
+    // SubjectManager, declared ahead of the subjects it owns so it tears down
+    // after them (names withdraw before storage dies).
+    SubjectManager subjects_;
 
     // Subject for toggling between list/edit views (0=list, 1=edit)
     lv_subject_t editing_subject_;

--- a/include/ui_spoolman_overlay.h
+++ b/include/ui_spoolman_overlay.h
@@ -19,6 +19,7 @@
 
 #include "moonraker_config_manager.h"
 #include "overlay_base.h"
+#include "subject_managed_panel.h"
 #include "system/moonraker_local_probe.h"
 
 #include <lvgl/lvgl.h>
@@ -259,6 +260,10 @@ class SpoolmanOverlay : public OverlayBase {
 
     /// Interval dropdown widget
     lv_obj_t* interval_dropdown_ = nullptr;
+
+    /// SubjectManager, declared ahead of the subjects it owns so it tears down
+    /// after them (names withdraw before storage dies).
+    SubjectManager subjects_;
 
     /// Subject for sync enabled state (0=disabled, 1=enabled)
     lv_subject_t sync_enabled_subject_;

--- a/include/ui_wizard_input_shaper.h
+++ b/include/ui_wizard_input_shaper.h
@@ -7,6 +7,7 @@
 #include "async_lifetime_guard.h"
 #include "input_shaper_calibrator.h"
 #include "lvgl/lvgl.h"
+#include "subject_managed_panel.h"
 #include "wizard_step.h"
 
 #include <atomic>
@@ -281,6 +282,10 @@ class WizardInputShaperStep : public helix::wizard::Step {
   private:
     // Screen instance
     lv_obj_t* screen_root_ = nullptr;
+
+    // SubjectManager, declared ahead of the subjects it owns so it tears down
+    // after them (names withdraw before storage dies).
+    SubjectManager subjects_;
 
     // Subjects
     lv_subject_t calibration_status_;

--- a/include/ui_wizard_language_chooser.h
+++ b/include/ui_wizard_language_chooser.h
@@ -5,6 +5,7 @@
 #include "ui_timer_guard.h"
 
 #include "lvgl/lvgl.h"
+#include "subject_managed_panel.h"
 #include "wizard_step.h"
 
 #include <atomic>
@@ -152,6 +153,10 @@ class WizardLanguageChooserStep : public helix::wizard::Step {
   private:
     // Screen instance
     lv_obj_t* screen_root_ = nullptr;
+
+    // SubjectManager, declared ahead of the subject it owns so it tears down
+    // after it (the name withdraws before the storage dies).
+    SubjectManager subjects_;
 
     // Subjects
     lv_subject_t welcome_text_;

--- a/src/system/subject_debug_registry.cpp
+++ b/src/system/subject_debug_registry.cpp
@@ -75,6 +75,11 @@ const SubjectDebugInfo* SubjectDebugRegistry::lookup(lv_subject_t* subject) {
     if (subject == nullptr) {
         return nullptr;
     }
+    // Mirrors unregister_subject(): a caller running during static destruction
+    // (SubjectManager::deinit_all) would otherwise lock a destroyed mutex_.
+    if (!g_registry_alive.load(std::memory_order_acquire)) {
+        return nullptr;
+    }
 
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = subjects_.find(subject);
@@ -108,6 +113,11 @@ std::string SubjectDebugRegistry::type_name(lv_subject_type_t type) {
 }
 
 lv_subject_t* SubjectDebugRegistry::lookup_by_name(const std::string& name) {
+    // Same late-caller safety as lookup(): deinit_all() consults this during
+    // static destruction and must not lock a destroyed mutex_.
+    if (!g_registry_alive.load(std::memory_order_acquire)) {
+        return nullptr;
+    }
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = name_to_subject_.find(name);
     if (it == name_to_subject_.end()) {

--- a/src/ui/ui_panel_bed_mesh.cpp
+++ b/src/ui/ui_panel_bed_mesh.cpp
@@ -198,17 +198,20 @@ void BedMeshPanel::init_subjects() {
             // Initialize with 5-arg form: (subject, buf, prev_buf, size, initial_value)
             lv_subject_init_string(&profile_name_subjects_[idx], name_buf, nullptr,
                                    profile_name_bufs_[idx].size(), "");
-            lv_xml_register_subject(nullptr, name_key.c_str(), &profile_name_subjects_[idx]);
-            subjects_.register_subject(&profile_name_subjects_[idx]);
+            helix::xml::register_subject_in_current_scope(name_key.c_str(),
+                                                          &profile_name_subjects_[idx]);
+            subjects_.register_subject(&profile_name_subjects_[idx], name_key.c_str());
 
             lv_subject_init_string(&profile_range_subjects_[idx], range_buf, nullptr,
                                    profile_range_bufs_[idx].size(), "");
-            lv_xml_register_subject(nullptr, range_key.c_str(), &profile_range_subjects_[idx]);
-            subjects_.register_subject(&profile_range_subjects_[idx]);
+            helix::xml::register_subject_in_current_scope(range_key.c_str(),
+                                                          &profile_range_subjects_[idx]);
+            subjects_.register_subject(&profile_range_subjects_[idx], range_key.c_str());
 
             lv_subject_init_int(&profile_active_subjects_[idx], 0);
-            lv_xml_register_subject(nullptr, active_key.c_str(), &profile_active_subjects_[idx]);
-            subjects_.register_subject(&profile_active_subjects_[idx]);
+            helix::xml::register_subject_in_current_scope(active_key.c_str(),
+                                                          &profile_active_subjects_[idx]);
+            subjects_.register_subject(&profile_active_subjects_[idx], active_key.c_str());
         }
 
         // Modal state subjects (NOT visibility - internal state only)

--- a/src/ui/ui_panel_print_status.cpp
+++ b/src/ui/ui_panel_print_status.cpp
@@ -789,9 +789,9 @@ void PrintStatusPanel::init_subjects() {
 
     // Exclude objects availability (0=hidden, 1=visible - shown when >= 2 objects defined)
     // Note: subject already initialized in constructor (needed before observer fires)
-    lv_xml_register_subject(nullptr, "exclude_objects_available",
-                            &exclude_objects_available_subject_);
-    subjects_.register_subject(&exclude_objects_available_subject_);
+    helix::xml::register_subject_in_current_scope("exclude_objects_available",
+                                                  &exclude_objects_available_subject_);
+    subjects_.register_subject(&exclude_objects_available_subject_, "exclude_objects_available");
     SubjectDebugRegistry::instance().register_subject(&exclude_objects_available_subject_,
                                                       "exclude_objects_available",
                                                       LV_SUBJECT_TYPE_INT, __FILE__, __LINE__);

--- a/src/ui/ui_panel_settings.cpp
+++ b/src/ui/ui_panel_settings.cpp
@@ -327,9 +327,8 @@ void SettingsPanel::init_subjects() {
     DisplayManager* dm = DisplayManager::instance();
     bool show_touch_cal = dm && dm->supports_touch_calibration();
 #endif
-    lv_subject_init_int(&show_touch_calibration_subject_, show_touch_cal ? 1 : 0);
-    subjects_.register_subject(&show_touch_calibration_subject_);
-    lv_xml_register_subject(nullptr, "show_touch_calibration", &show_touch_calibration_subject_);
+    UI_MANAGED_SUBJECT_INT(show_touch_calibration_subject_, show_touch_cal ? 1 : 0,
+                           "show_touch_calibration", subjects_);
 
     // Note: show_beta_features subject is initialized globally in app_globals.cpp
 
@@ -341,9 +340,8 @@ void SettingsPanel::init_subjects() {
     // out of scope (ethernet_manager.h still resolves to the
     // helixapp_platform_stubs.cpp seam; no ESP32 wired-network HIL exists).
     bool show_network_settings = !on_android;
-    lv_subject_init_int(&show_network_settings_subject_, show_network_settings ? 1 : 0);
-    subjects_.register_subject(&show_network_settings_subject_);
-    lv_xml_register_subject(nullptr, "show_network_settings", &show_network_settings_subject_);
+    UI_MANAGED_SUBJECT_INT(show_network_settings_subject_, show_network_settings ? 1 : 0,
+                           "show_network_settings", subjects_);
 
     // Update checker runs on all platforms — on Android, "Install Update"
     // redirects to the Play Store instead of self-updating.
@@ -357,19 +355,15 @@ void SettingsPanel::init_subjects() {
     // about it.
     bool externally_managed = updates_externally_managed();
     bool install_suppressed = update_install_suppressed();
-    lv_subject_init_int(&show_update_settings_subject_, update_checks_suppressed() ? 0 : 1);
-    subjects_.register_subject(&show_update_settings_subject_);
-    lv_xml_register_subject(nullptr, "show_update_settings", &show_update_settings_subject_);
+    UI_MANAGED_SUBJECT_INT(show_update_settings_subject_, update_checks_suppressed() ? 0 : 1,
+                           "show_update_settings", subjects_);
 
-    lv_subject_init_int(&updates_firmware_managed_subject_, externally_managed ? 1 : 0);
-    subjects_.register_subject(&updates_firmware_managed_subject_);
-    lv_xml_register_subject(nullptr, "updates_firmware_managed",
-                            &updates_firmware_managed_subject_);
+    UI_MANAGED_SUBJECT_INT(updates_firmware_managed_subject_, externally_managed ? 1 : 0,
+                           "updates_firmware_managed", subjects_);
 
-    lv_subject_init_int(&updates_unavailable_subject_,
-                        (install_suppressed && !externally_managed) ? 1 : 0);
-    subjects_.register_subject(&updates_unavailable_subject_);
-    lv_xml_register_subject(nullptr, "updates_unavailable", &updates_unavailable_subject_);
+    UI_MANAGED_SUBJECT_INT(updates_unavailable_subject_,
+                           (install_suppressed && !externally_managed) ? 1 : 0,
+                           "updates_unavailable", subjects_);
 
     // Touch calibration status - show "Calibrated" or "Not calibrated" in row description
     Config* config = Config::get_instance();

--- a/src/ui/ui_settings_barcode_scanner.cpp
+++ b/src/ui/ui_settings_barcode_scanner.cpp
@@ -66,13 +66,6 @@ BarcodeScannerSettingsOverlay::~BarcodeScannerSettingsOverlay() {
     // while the process continues, promote the discovery thread to joinable.
     stop_bt_discovery();
 
-    if (subjects_initialized_) {
-        lv_subject_deinit(&bt_available_subject_);
-        lv_subject_deinit(&bt_discovering_subject_);
-        lv_subject_deinit(&keymap_index_subject_);
-        lv_subject_deinit(&current_device_label_subject_);
-    }
-
     if (bt_ctx_) {
         auto& loader = helix::bluetooth::BluetoothLoader::instance();
         if (loader.deinit) {
@@ -93,11 +86,10 @@ void BarcodeScannerSettingsOverlay::init_subjects() {
         return;
 
     auto& loader = helix::bluetooth::BluetoothLoader::instance();
-    lv_subject_init_int(&bt_available_subject_, loader.is_available() ? 1 : 0);
-    lv_xml_register_subject(nullptr, "scanner_bt_available", &bt_available_subject_);
+    UI_MANAGED_SUBJECT_INT(bt_available_subject_, loader.is_available() ? 1 : 0,
+                           "scanner_bt_available", subjects_);
 
-    lv_subject_init_int(&bt_discovering_subject_, 0);
-    lv_xml_register_subject(nullptr, "scanner_bt_discovering", &bt_discovering_subject_);
+    UI_MANAGED_SUBJECT_INT(bt_discovering_subject_, 0, "scanner_bt_discovering", subjects_);
 
     const std::string km = helix::SettingsManager::instance().get_scanner_keymap();
     int km_idx = 0;
@@ -105,14 +97,10 @@ void BarcodeScannerSettingsOverlay::init_subjects() {
         km_idx = 1;
     else if (km == "azerty")
         km_idx = 2;
-    lv_subject_init_int(&keymap_index_subject_, km_idx);
-    lv_xml_register_subject(nullptr, "scanner_keymap_index", &keymap_index_subject_);
+    UI_MANAGED_SUBJECT_INT(keymap_index_subject_, km_idx, "scanner_keymap_index", subjects_);
 
-    current_device_label_buf_[0] = '\0';
-    lv_subject_init_string(&current_device_label_subject_, current_device_label_buf_, nullptr,
-                           sizeof(current_device_label_buf_), current_device_label_buf_);
-    lv_xml_register_subject(nullptr, "scanner_current_device_label",
-                            &current_device_label_subject_);
+    UI_MANAGED_SUBJECT_STRING(current_device_label_subject_, current_device_label_buf_, "",
+                              "scanner_current_device_label", subjects_);
 
     subjects_initialized_ = true;
     spdlog::debug("[{}] Subjects initialized", get_name());

--- a/src/ui/ui_settings_display_sound.cpp
+++ b/src/ui/ui_settings_display_sound.cpp
@@ -78,10 +78,6 @@ DisplaySoundSettingsOverlay::DisplaySoundSettingsOverlay() {
 }
 
 DisplaySoundSettingsOverlay::~DisplaySoundSettingsOverlay() {
-    if (subjects_initialized_ && lv_is_initialized()) {
-        lv_subject_deinit(&brightness_value_subject_);
-        lv_subject_deinit(&theme_apply_disabled_subject_);
-    }
     spdlog::trace("[{}] Destroyed", get_name());
 }
 
@@ -96,13 +92,11 @@ void DisplaySoundSettingsOverlay::init_subjects() {
 
     // Brightness value subject for label binding
     snprintf(brightness_value_buf_, sizeof(brightness_value_buf_), "100%%");
-    lv_subject_init_string(&brightness_value_subject_, brightness_value_buf_, nullptr,
-                           sizeof(brightness_value_buf_), brightness_value_buf_);
-    lv_xml_register_subject(nullptr, "brightness_value", &brightness_value_subject_);
+    UI_MANAGED_SUBJECT_STRING(brightness_value_subject_, brightness_value_buf_,
+                              brightness_value_buf_, "brightness_value", subjects_);
 
     // Theme Apply button disabled subject (1=disabled initially)
-    lv_subject_init_int(&theme_apply_disabled_subject_, 1);
-    lv_xml_register_subject(nullptr, "theme_apply_disabled", &theme_apply_disabled_subject_);
+    UI_MANAGED_SUBJECT_INT(theme_apply_disabled_subject_, 1, "theme_apply_disabled", subjects_);
 
     subjects_initialized_ = true;
     spdlog::debug("[{}] Subjects initialized", get_name());

--- a/src/ui/ui_settings_fans.cpp
+++ b/src/ui/ui_settings_fans.cpp
@@ -64,9 +64,6 @@ FanSettingsOverlay::FanSettingsOverlay() {
 }
 
 FanSettingsOverlay::~FanSettingsOverlay() {
-    if (rename_subject_initialized_ && lv_is_initialized()) {
-        lv_subject_deinit(&fan_rename_old_name_);
-    }
     spdlog::trace("[{}] Destroyed", get_name());
 }
 
@@ -329,10 +326,8 @@ void FanSettingsOverlay::handle_fan_rename(const std::string& object_name,
 
     // Lazy-init the subject on first use (avoids startup init order issues)
     if (!rename_subject_initialized_) {
-        std::memset(rename_old_name_buf_, 0, sizeof(rename_old_name_buf_));
-        lv_subject_init_string(&fan_rename_old_name_, rename_old_name_buf_, nullptr,
-                               sizeof(rename_old_name_buf_), "");
-        lv_xml_register_subject(nullptr, "fan_rename_old_name", &fan_rename_old_name_);
+        UI_MANAGED_SUBJECT_STRING(fan_rename_old_name_, rename_old_name_buf_, "",
+                                  "fan_rename_old_name", subjects_);
         rename_subject_initialized_ = true;
     }
 

--- a/src/ui/ui_settings_label_printer.cpp
+++ b/src/ui/ui_settings_label_printer.cpp
@@ -146,13 +146,6 @@ LabelPrinterSettingsOverlay::~LabelPrinterSettingsOverlay() {
     stop_usb_detection();
     stop_bt_discovery();
 
-    // Deinit subjects
-    if (subjects_initialized_) {
-        lv_subject_deinit(&bt_scanning_subject_);
-        lv_subject_deinit(&test_printing_subject_);
-        lv_subject_deinit(&ipp_selected_subject_);
-    }
-
     // Deinit BT context only in destructor, not in stop_bt_discovery()
     if (bt_ctx_) {
         auto& loader = helix::bluetooth::BluetoothLoader::instance();
@@ -177,23 +170,24 @@ void LabelPrinterSettingsOverlay::init_subjects() {
     // Ensure manager subjects are initialized (reads config for initial value)
     LabelPrinterSettingsManager::instance().init_subjects();
 
-    // Register C++-owned subject globally so XML bind_flag_if_not_eq can find it
+    // Register C++-owned subject globally so XML bind_flag_if_not_eq can find it.
+    // Deliberately NOT registered with subjects_: the name aliases
+    // LabelPrinterSettingsManager's subject (owner registered as
+    // "label_printer_type"), a process-lifetime singleton — its storage
+    // outlives this overlay, so the name never dangles (prestonbrown/helixscreen#1538).
     lv_xml_register_subject(nullptr, "printer_type_subject",
                             LabelPrinterSettingsManager::instance().subject_printer_type());
 
     // BT scanning state subject (0=idle, 1=scanning)
-    lv_subject_init_int(&bt_scanning_subject_, 0);
-    lv_xml_register_subject(nullptr, "bt_scanning", &bt_scanning_subject_);
-    lv_subject_init_int(&test_printing_subject_, 0);
-    lv_xml_register_subject(nullptr, "test_printing", &test_printing_subject_);
+    UI_MANAGED_SUBJECT_INT(bt_scanning_subject_, 0, "bt_scanning", subjects_);
+    UI_MANAGED_SUBJECT_INT(test_printing_subject_, 0, "test_printing", subjects_);
 
     // IPP selected subject (0=not IPP, 1=IPP protocol selected within network type)
     int ipp_initial = (LabelPrinterSettingsManager::instance().get_printer_type() == "network" &&
                        LabelPrinterSettingsManager::instance().get_printer_protocol() == "ipp")
                           ? 1
                           : 0;
-    lv_subject_init_int(&ipp_selected_subject_, ipp_initial);
-    lv_xml_register_subject(nullptr, "ipp_selected", &ipp_selected_subject_);
+    UI_MANAGED_SUBJECT_INT(ipp_selected_subject_, ipp_initial, "ipp_selected", subjects_);
 
     subjects_initialized_ = true;
     spdlog::debug("[{}] Subjects initialized", get_name());

--- a/src/ui/ui_settings_material_temps.cpp
+++ b/src/ui/ui_settings_material_temps.cpp
@@ -51,12 +51,6 @@ MaterialTempsOverlay::MaterialTempsOverlay() {
 }
 
 MaterialTempsOverlay::~MaterialTempsOverlay() {
-    if (subjects_initialized_ && lv_is_initialized()) {
-        lv_subject_deinit(&has_macro_subject_);
-        lv_subject_deinit(&editing_subject_);
-        lv_subject_deinit(&edit_name_subject_);
-        lv_subject_deinit(&edit_defaults_subject_);
-    }
     spdlog::trace("[{}] Destroyed", get_name());
 }
 
@@ -70,22 +64,16 @@ void MaterialTempsOverlay::init_subjects() {
     }
 
     // View toggle subject: 0=list, 1=editing
-    lv_subject_init_int(&editing_subject_, 0);
-    lv_xml_register_subject(nullptr, "material_editing", &editing_subject_);
+    UI_MANAGED_SUBJECT_INT(editing_subject_, 0, "material_editing", subjects_);
 
     // Edit view text subjects
-    edit_name_buf_[0] = '\0';
-    lv_subject_init_string(&edit_name_subject_, edit_name_buf_, nullptr, sizeof(edit_name_buf_),
-                           edit_name_buf_);
-    lv_xml_register_subject(nullptr, "material_edit_name", &edit_name_subject_);
+    UI_MANAGED_SUBJECT_STRING(edit_name_subject_, edit_name_buf_, "", "material_edit_name",
+                              subjects_);
 
-    edit_defaults_buf_[0] = '\0';
-    lv_subject_init_string(&edit_defaults_subject_, edit_defaults_buf_, nullptr,
-                           sizeof(edit_defaults_buf_), edit_defaults_buf_);
-    lv_xml_register_subject(nullptr, "material_edit_defaults", &edit_defaults_subject_);
+    UI_MANAGED_SUBJECT_STRING(edit_defaults_subject_, edit_defaults_buf_, "",
+                              "material_edit_defaults", subjects_);
 
-    lv_subject_init_int(&has_macro_subject_, 0);
-    lv_xml_register_subject(nullptr, "material_has_macro", &has_macro_subject_);
+    UI_MANAGED_SUBJECT_INT(has_macro_subject_, 0, "material_has_macro", subjects_);
 
     subjects_initialized_ = true;
     spdlog::debug("[{}] Subjects initialized", get_name());

--- a/src/ui/ui_spoolman_overlay.cpp
+++ b/src/ui/ui_spoolman_overlay.cpp
@@ -76,11 +76,6 @@ SpoolmanOverlay::SpoolmanOverlay() {
 }
 
 SpoolmanOverlay::~SpoolmanOverlay() {
-    if (subjects_initialized_ && lv_is_initialized()) {
-        lv_subject_deinit(&sync_enabled_subject_);
-        lv_subject_deinit(&refresh_interval_subject_);
-        lv_subject_deinit(&scanner_device_status_subject_);
-    }
     spdlog::trace("[{}] Destroyed", get_name());
 }
 
@@ -94,21 +89,20 @@ void SpoolmanOverlay::init_subjects() {
     }
 
     // Initialize sync enabled subject (default: true/enabled)
-    lv_subject_init_int(&sync_enabled_subject_, DEFAULT_SYNC_ENABLED ? 1 : 0);
-    lv_xml_register_subject(nullptr, "ams_spoolman_sync_enabled", &sync_enabled_subject_);
+    UI_MANAGED_SUBJECT_INT(sync_enabled_subject_, DEFAULT_SYNC_ENABLED ? 1 : 0,
+                           "ams_spoolman_sync_enabled", subjects_);
 
     // Initialize refresh interval subject (default: 30 seconds)
-    lv_subject_init_int(&refresh_interval_subject_, DEFAULT_REFRESH_INTERVAL_SECONDS);
-    lv_xml_register_subject(nullptr, "ams_spoolman_refresh_interval", &refresh_interval_subject_);
+    UI_MANAGED_SUBJECT_INT(refresh_interval_subject_, DEFAULT_REFRESH_INTERVAL_SECONDS,
+                           "ams_spoolman_refresh_interval", subjects_);
 
     // Initialize scanner device status subject
     auto scanner_name = helix::SettingsManager::instance().get_scanner_device_name();
     auto scanner_id = helix::SettingsManager::instance().get_scanner_device_id();
     const char* status = scanner_id.empty() ? lv_tr("Auto-detect") : scanner_name.c_str();
     snprintf(scanner_status_buf_, sizeof(scanner_status_buf_), "%s", status);
-    lv_subject_init_string(&scanner_device_status_subject_, scanner_status_buf_, nullptr,
-                           sizeof(scanner_status_buf_), scanner_status_buf_);
-    lv_xml_register_subject(nullptr, "scanner_device_status", &scanner_device_status_subject_);
+    UI_MANAGED_SUBJECT_STRING(scanner_device_status_subject_, scanner_status_buf_,
+                              scanner_status_buf_, "scanner_device_status", subjects_);
 
     subjects_initialized_ = true;
     spdlog::debug("[{}] Subjects initialized", get_name());

--- a/src/ui/ui_wizard_input_shaper.cpp
+++ b/src/ui/ui_wizard_input_shaper.cpp
@@ -62,17 +62,6 @@ WizardInputShaperStep::~WizardInputShaperStep() {
     // ordering explicit).
     cancel_analysis_display();
 
-    // Deinitialize subjects to disconnect observers before destruction
-    // NOTE: lv_subject_deinit() is safe to call even during shutdown
-    if (subjects_initialized_) {
-        lv_subject_deinit(&calibration_status_);
-        lv_subject_deinit(&calibration_progress_);
-        lv_subject_deinit(&calibration_started_);
-        lv_subject_deinit(&calibration_active_);
-        lv_subject_deinit(&calibration_indeterminate_);
-        subjects_initialized_ = false;
-    }
-
     // NOTE: Do NOT log here - spdlog may be destroyed first
     screen_root_ = nullptr;
 }
@@ -93,24 +82,23 @@ void WizardInputShaperStep::init_subjects() {
     // Initialize status subject with string buffer
     strncpy(status_buffer_, "Ready to calibrate", sizeof(status_buffer_) - 1);
     status_buffer_[sizeof(status_buffer_) - 1] = '\0';
-    lv_subject_init_string(&calibration_status_, status_buffer_, nullptr, sizeof(status_buffer_),
-                           status_buffer_);
-    lv_xml_register_subject(nullptr, "wizard_input_shaper_status", &calibration_status_);
+    UI_MANAGED_SUBJECT_STRING(calibration_status_, status_buffer_, status_buffer_,
+                              "wizard_input_shaper_status", subjects_);
 
     // Initialize progress subject
-    helix::ui::wizard::init_int_subject(&calibration_progress_, 0, "wizard_input_shaper_progress");
+    UI_MANAGED_SUBJECT_INT(calibration_progress_, 0, "wizard_input_shaper_progress", subjects_);
 
     // Initialize started subject (controls Start button and skip hint visibility)
-    helix::ui::wizard::init_int_subject(&calibration_started_, 0, "wizard_input_shaper_started");
+    UI_MANAGED_SUBJECT_INT(calibration_started_, 0, "wizard_input_shaper_started", subjects_);
 
     // Initialize active subject (controls Cancel button visibility — 1 only while
     // calibration is in flight; cleared on complete / cancel / error)
-    helix::ui::wizard::init_int_subject(&calibration_active_, 0, "wizard_input_shaper_active");
+    UI_MANAGED_SUBJECT_INT(calibration_active_, 0, "wizard_input_shaper_active", subjects_);
 
     // Initialize indeterminate subject (1 during the offline analysis phase:
     // hides the bar, shows the spinner)
-    helix::ui::wizard::init_int_subject(&calibration_indeterminate_, 0,
-                                        "wizard_input_shaper_indeterminate");
+    UI_MANAGED_SUBJECT_INT(calibration_indeterminate_, 0, "wizard_input_shaper_indeterminate",
+                           subjects_);
 
     subjects_initialized_ = true;
     spdlog::debug("[{}] Subjects initialized", get_name());

--- a/src/ui/ui_wizard_language_chooser.cpp
+++ b/src/ui/ui_wizard_language_chooser.cpp
@@ -84,12 +84,6 @@ WizardLanguageChooserStep::WizardLanguageChooserStep() {
 WizardLanguageChooserStep::~WizardLanguageChooserStep() {
     // Timer guard handles cleanup automatically via RAII
 
-    // Deinitialize subjects to disconnect observers before destruction
-    if (subjects_initialized_) {
-        lv_subject_deinit(&welcome_text_);
-        subjects_initialized_ = false;
-    }
-
     screen_root_ = nullptr;
 }
 
@@ -109,9 +103,8 @@ void WizardLanguageChooserStep::init_subjects() {
     // Initialize welcome text subject with string buffer
     strncpy(welcome_buffer_, WELCOME_TRANSLATIONS[0], sizeof(welcome_buffer_) - 1);
     welcome_buffer_[sizeof(welcome_buffer_) - 1] = '\0';
-    lv_subject_init_string(&welcome_text_, welcome_buffer_, nullptr, sizeof(welcome_buffer_),
-                           welcome_buffer_);
-    lv_xml_register_subject(nullptr, "wizard_welcome_text", &welcome_text_);
+    UI_MANAGED_SUBJECT_STRING(welcome_text_, welcome_buffer_, welcome_buffer_,
+                              "wizard_welcome_text", subjects_);
 
     subjects_initialized_ = true;
     spdlog::debug("[{}] Subjects initialized", get_name());

--- a/tests/unit/test_subject_name_withdrawal.cpp
+++ b/tests/unit/test_subject_name_withdrawal.cpp
@@ -1,0 +1,168 @@
+// Copyright (C) 2025-2026 356C LLC
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_subject_name_withdrawal.cpp
+ * @brief Subject names must leave the XML scope when their owner is torn down.
+ *
+ * prestonbrown/helixscreen#1538: objects freed mid-process by
+ * StaticPanelRegistry::destroy_all() published names into the global XML
+ * subject scope without withdrawing them, so the next lv_xml_create() that
+ * bound one installed an observer inside freed storage. The fix moves
+ * registration onto SubjectManager (names recorded at registration, withdrawn
+ * before deinit) and hardens deinit_all() against the silent variant where a
+ * subject was registered WITHOUT a name while still published under one.
+ */
+
+#include "ui_settings_barcode_scanner.h"
+#include "ui_settings_display_sound.h"
+#include "ui_settings_label_printer.h"
+#include "ui_settings_material_temps.h"
+#include "ui_spoolman_overlay.h"
+#include "ui_wizard_input_shaper.h"
+#include "ui_wizard_language_chooser.h"
+
+#include "../test_fixtures.h"
+#include "helix-xml/src/xml/lv_xml.h"
+#include "static_panel_registry.h"
+#include "subject_debug_registry.h"
+#include "subject_managed_panel.h"
+
+#include <lvgl/lvgl.h>
+
+#include <string>
+#include <vector>
+
+#include "../catch_amalgamated.hpp"
+
+namespace helix::settings {
+DisplaySoundSettingsOverlay& get_display_sound_settings_overlay();
+MaterialTempsOverlay& get_material_temps_overlay();
+LabelPrinterSettingsOverlay& get_label_printer_settings_overlay();
+} // namespace helix::settings
+
+namespace helix::ui {
+SpoolmanOverlay& get_spoolman_overlay();
+BarcodeScannerSettingsOverlay& get_barcode_scanner_settings_overlay();
+} // namespace helix::ui
+
+WizardInputShaperStep* get_wizard_input_shaper_step();
+WizardLanguageChooserStep* get_wizard_language_chooser_step();
+
+namespace {
+
+struct OverlayCase {
+    const char* label;
+    void (*init_fn)();
+    std::vector<const char*> names;
+};
+
+} // namespace
+
+TEST_CASE_METHOD(XMLTestFixture,
+                 "SubjectManager withdraws a nameless registration that is published anyway",
+                 "[subject-scope][1538]") {
+    constexpr const char* kName = "nameless_trap_probe";
+
+    lv_subject_t subject{};
+    lv_subject_init_int(&subject, 0);
+
+    // The silent variant: published under a name, handed to the manager
+    // without it. The raw register plus the debug record model what a
+    // previous caller left behind; the manager only sees the one-arg
+    // registration.
+    lv_xml_register_subject(nullptr, kName, &subject);
+    SubjectDebugRegistry::instance().register_subject(&subject, kName, LV_SUBJECT_TYPE_INT,
+                                                      __FILE__, __LINE__);
+
+    {
+        SubjectManager manager;
+        manager.register_subject(&subject);
+        manager.deinit_all();
+    }
+
+    // The withdrawal is what prevents the next lv_xml_create() from binding
+    // freed storage; the debug registry must not answer for the pointer
+    // either.
+    CHECK(lv_xml_get_subject(nullptr, kName) == nullptr);
+    CHECK(SubjectDebugRegistry::instance().lookup(&subject) == nullptr);
+}
+
+TEST_CASE_METHOD(XMLTestFixture,
+                 "SubjectManager deinit leaves a truly unnamed subject without crashing",
+                 "[subject-scope][1538]") {
+    // The conservative inventory also names subjects that were never
+    // published (direct bindings, no scope entry). Teardown must keep
+    // deinitializing those quietly.
+    lv_subject_t subject{};
+    lv_subject_init_int(&subject, 0);
+
+    SubjectManager manager;
+    manager.register_subject(&subject);
+    manager.deinit_all();
+
+    CHECK(lv_xml_get_subject(nullptr, "never_published_probe") == nullptr);
+}
+
+TEST_CASE_METHOD(XMLTestFixture, "Converted overlays withdraw their subject names on destroy_all",
+                 "[subject-scope][1538]") {
+    StaticPanelRegistry::instance().destroy_all();
+
+    const OverlayCase cases[] = {
+        {"DisplaySound",
+         []() { helix::settings::get_display_sound_settings_overlay().init_subjects(); },
+         {"brightness_value", "theme_apply_disabled"}},
+        {"MaterialTemps",
+         []() { helix::settings::get_material_temps_overlay().init_subjects(); },
+         {"material_editing", "material_edit_name", "material_edit_defaults",
+          "material_has_macro"}},
+        {"Spoolman",
+         []() { helix::ui::get_spoolman_overlay().init_subjects(); },
+         {"ams_spoolman_sync_enabled", "ams_spoolman_refresh_interval", "scanner_device_status"}},
+        {"BarcodeScanner",
+         []() { helix::ui::get_barcode_scanner_settings_overlay().init_subjects(); },
+         {"scanner_bt_available", "scanner_bt_discovering", "scanner_keymap_index",
+          "scanner_current_device_label"}},
+        {"LabelPrinter",
+         []() { helix::settings::get_label_printer_settings_overlay().init_subjects(); },
+         {"bt_scanning", "test_printing", "ipp_selected"}},
+        {"WizardLanguageChooser",
+         []() {
+             WizardLanguageChooserStep* step = get_wizard_language_chooser_step();
+             REQUIRE(step != nullptr);
+             step->init_subjects();
+         },
+         {"wizard_welcome_text"}},
+        {"WizardInputShaper",
+         []() {
+             WizardInputShaperStep* step = get_wizard_input_shaper_step();
+             REQUIRE(step != nullptr);
+             step->init_subjects();
+         },
+         {"wizard_input_shaper_status", "wizard_input_shaper_progress",
+          "wizard_input_shaper_started", "wizard_input_shaper_active",
+          "wizard_input_shaper_indeterminate"}},
+    };
+
+    for (const auto& c : cases) {
+        INFO(c.label);
+        c.init_fn();
+        for (const char* name : c.names) {
+            INFO(c.label);
+            INFO(name);
+            // The absence assertions below only mean something if the names
+            // were there to withdraw.
+            REQUIRE(lv_xml_get_subject(nullptr, name) != nullptr);
+        }
+    }
+
+    StaticPanelRegistry::instance().destroy_all();
+
+    for (const auto& c : cases) {
+        for (const char* name : c.names) {
+            INFO(c.label);
+            INFO(name);
+            CHECK(lv_xml_get_subject(nullptr, name) == nullptr);
+        }
+    }
+}


### PR DESCRIPTION
All 11 variant-1 files register their panel-owned subjects through
SubjectManager now (UI_MANAGED_SUBJECT_* or register_subject(&s, name) for
computed names), with subjects_ declared ahead of the subjects it owns, and
the hand-rolled lv_subject_deinit lists in destructors are gone. deinit_all()
already withdraws each recorded name before freeing the subject.

deinit_all() is hardened against the silent variant: a subject registered
WITHOUT a name while still published under one (debug registry lookups find
it) is withdrawn and reported as a subject_manager_nameless_registered
anomaly. The withdrawal checks the name still resolves to this subject so a
newer owner's binding is never stranded. lookup()/lookup_by_name() on
SubjectDebugRegistry gain the same late-caller liveness guard
unregister_subject() had.

Deliberate exceptions left raw (issue's own ams_edit_overlay precedent):
printer_type_subject aliases LabelPrinterSettingsManager's process-lifetime
subject (annotated), and the ams_state 41 are a process singleton.

Tests: [1538] pins the trap withdrawal (name resolves, then does not) and
names-exit for seven converted overlays. mutation: the guard hunk and 9
conversion hunks went red; the remaining survival set is the shared-shape
machinery (no cheap fixture drives settings/bed_mesh/print_status/fans
init_subjects; dtor-list reversions are behavior-neutral because the manager
holds the same subjects) plus the header-include hunks, which compile either
way because their member hunks force the type.
