### PR TITLE
fix(home): re-resolve printer artwork when auto-detection settles mid-session

### DIFF
--- a/include/printer_state.h
+++ b/include/printer_state.h
@@ -2318,6 +2318,19 @@ class PrinterState {
     }
 
     /**
+     * @brief Get the printer type subject
+     *
+     * String subject updated on every change to the resolved printer type
+     * (detection, wizard, printer manager). Consumers that resolved state
+     * from the type at attach time — printer artwork, for one — re-resolve
+     * by observing it, since auto-detection settles after the home panel
+     * is built on a fresh install.
+     */
+    lv_subject_t* get_printer_type_subject() {
+        return &printer_type_subject_;
+    }
+
+    /**
      * @brief Set the active printer display name
      *
      * Updates the string subject with the given name. Main-thread only.
@@ -2440,6 +2453,9 @@ class PrinterState {
     // Multi-printer subjects (owned directly by PrinterState)
     lv_subject_t active_printer_name_;
     char active_printer_name_buf_[128];
+
+    lv_subject_t printer_type_subject_;
+    char printer_type_subject_buf_[128];
 
     // JSON cache for complex data
     json json_state_;

--- a/include/printer_state.h
+++ b/include/printer_state.h
@@ -2325,6 +2325,11 @@ class PrinterState {
      * from the type at attach time — printer artwork, for one — re-resolve
      * by observing it, since auto-detection settles after the home panel
      * is built on a fresh install.
+     *
+     * The subject resets to "" on deinit_subjects()/re-init, and the
+     * setter's no-change early return means a soft restart repopulates it
+     * only on the next real type change. Treat it as a change signal and
+     * read the value from Config or get_printer_type().
      */
     lv_subject_t* get_printer_type_subject() {
         return &printer_type_subject_;

--- a/src/printer/printer_state.cpp
+++ b/src/printer/printer_state.cpp
@@ -301,6 +301,11 @@ void PrinterState::init_subjects(bool register_xml) {
     // Multi-printer subjects (owned directly by PrinterState)
     INIT_SUBJECT_STRING(active_printer_name, "", subjects_, register_xml);
 
+    // Resolved printer type. Not XML-registered: the name collides with the
+    // connection-transport int subject ("network"/"usb"/"bluetooth"), and no
+    // XML binds it — observers attach programmatically (printer artwork).
+    INIT_SUBJECT_STRING(printer_type_subject, "", subjects_, false);
+
     // Z-offset save visibility (1 = manual save needed, 0 = firmware auto-saves)
     INIT_SUBJECT_INT(z_offset_can_save, 1, subjects_, register_xml);
 
@@ -1259,6 +1264,10 @@ void PrinterState::set_printer_type_internal(const std::string& type) {
     printer_type_ = type;
     pre_print_option_set_ = new_options;
     z_offset_calibration_strategy_ = new_strategy;
+
+    if (subjects_initialized_) {
+        lv_subject_copy_string(&printer_type_subject_, type.c_str());
+    }
 
     // Synthesize runtime-dependent options (timelapse) on top of the DB load.
     apply_dynamic_options();

--- a/src/ui/panel_widgets/printer_image_widget.cpp
+++ b/src/ui/panel_widgets/printer_image_widget.cpp
@@ -10,6 +10,7 @@
 #include "app_globals.h"
 #include "config.h"
 #include "http_executor.h"
+#include "observer_factory.h"
 #include "panel_widget_registry.h"
 #include "prerendered_images.h"
 #include "printer_detector.h"
@@ -114,10 +115,22 @@ void PrinterImageWidget::attach(lv_obj_t* widget_obj, lv_obj_t* parent_screen) {
     // Load printer image and info from config
     reload_from_config();
 
+    // attach() runs on every rebuild of a recycled instance, so re-arming here
+    // keeps the observer alive across home-panel rebuilds.
+    printer_type_observer_ = helix::ui::observe_string<PrinterImageWidget>(
+        get_printer_state().get_printer_type_subject(), this,
+        [](PrinterImageWidget* w, const char* /*type*/) { w->schedule_image_refresh(); },
+        get_printer_state().get_subjects_lifetime());
+
     spdlog::debug("[PrinterImageWidget] Attached");
 }
 
 void PrinterImageWidget::detach() {
+    // Drop the type observer first: any handler it has queued on the
+    // UpdateQueue holds a weak alive token that this reset expires, so a
+    // deferred refresh can't land on a detached tree.
+    printer_type_observer_.reset();
+
     // Cancel any pending timers. detach() runs from the destructor, so cancelling
     // here makes the deferred timers lifetime-safe (main-thread work — no
     // AsyncLifetimeGuard needed).

--- a/src/ui/panel_widgets/printer_image_widget.h
+++ b/src/ui/panel_widgets/printer_image_widget.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "ui_observer_guard.h"
+
 #include "async_lifetime_guard.h"
 #include "panel_widget.h"
 
@@ -62,6 +64,12 @@ class PrinterImageWidget : public PanelWidget {
     /// another cache check, and without this a second job would redo work already
     /// running for the same source and size.
     bool cache_job_inflight_ = false;
+
+    /// Re-resolves the image when the printer type settles mid-session:
+    /// auto-detection finishes after the home panel is built on a fresh
+    /// install, so attach()'s one-shot resolve still shows the generic
+    /// silhouette unless a type change re-triggers it.
+    ObserverGuard printer_type_observer_;
 
     void schedule_image_refresh();
     void schedule_cache_check();

--- a/tests/unit/test_printer_image_widget.cpp
+++ b/tests/unit/test_printer_image_widget.cpp
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2025-2026 356C LLC
 
+#include "ui_update_queue.h"
+
 #include "../test_fixtures.h"
+#include "app_globals.h"
+#include "config.h"
 #include "misc/lv_timer_private.h"
 #include "panel_widget_manager.h"
 #include "panel_widget_registry.h"
 #include "prerendered_images.h"
 #include "src/ui/panel_widgets/printer_image_widget.h"
+#include "wizard_config_paths.h"
 
 #include <filesystem>
 #include <string>
@@ -196,4 +201,101 @@ TEST_CASE_METHOD(XMLTestFixture, "PrinterImageWidget generates its image cache o
 
     widget.detach();
     std::filesystem::remove(cache_path, ec);
+}
+
+// The printer-type subject publishes every change to the resolved type, and the
+// setter's early return (same type + same z-offset strategy) must not re-notify.
+// Consumers like PrinterImageWidget re-resolve on this subject, so a duplicate
+// notification is a wasted config read + layout, not just noise.
+TEST_CASE_METHOD(XMLTestFixture, "PrinterState type subject fires only when the type changes",
+                 "[1552][printer_state][panel_widget]") {
+    int fires = 0;
+    lv_observer_t* obs = lv_subject_add_observer(
+        state().get_printer_type_subject(),
+        [](lv_observer_t* o, lv_subject_t*) { ++*static_cast<int*>(lv_observer_get_user_data(o)); },
+        &fires);
+    REQUIRE(obs != nullptr);
+    REQUIRE(fires == 1); // observers run once on attach with the current value
+
+    state().set_printer_type_sync("Voron 2.4");
+    REQUIRE(fires == 2);
+    REQUIRE(std::string(lv_subject_get_string(state().get_printer_type_subject())) == "Voron 2.4");
+
+    // Same type: the early-return path must not re-notify.
+    state().set_printer_type_sync("Voron 2.4");
+    REQUIRE(fires == 2);
+
+    state().set_printer_type_sync("Creality K1C");
+    REQUIRE(fires == 3);
+    REQUIRE(std::string(lv_subject_get_string(state().get_printer_type_subject())) ==
+            "Creality K1C");
+
+    lv_observer_remove(obs);
+}
+
+// On a fresh install auto-detection settles AFTER the home panel is built, so
+// attach()'s one-shot resolve shows the generic silhouette and nothing re-runs
+// it for the rest of the session. The widget observes the printer-type subject
+// and re-resolves when the detected type lands.
+TEST_CASE_METHOD(XMLTestFixture,
+                 "PrinterImageWidget re-resolves its image when the type settles after attach",
+                 "[1552][panel_widget][printer_image][regression]") {
+    helix::init_widget_registrations();
+    helix::PanelWidgetManager::instance().init_widget_subjects();
+
+    // The widget observes the process-wide PrinterState, whose subjects this
+    // fixture does not initialize (its own per-instance state owns the XML
+    // scope). Without this the observer silently fails to attach and the
+    // detection below changes nothing.
+    get_printer_state().init_subjects(false);
+
+    auto build_tree = [&](lv_obj_t*& widget_obj, lv_obj_t*& img) {
+        lv_obj_t* container = lv_obj_create(test_screen());
+        lv_obj_set_size(container, 200, 200);
+        widget_obj = lv_obj_create(container);
+        img = lv_image_create(widget_obj);
+        lv_obj_set_name(img, "printer_image");
+        process_lvgl(2);
+    };
+
+    lv_obj_t* widget_obj = nullptr;
+    lv_obj_t* img = nullptr;
+    build_tree(widget_obj, img);
+
+    helix::PrinterImageWidget w;
+    w.attach(widget_obj, test_screen());
+    helix::ui::UpdateQueue::instance().drain();
+    process_async_calls();
+
+    const char* first_raw = static_cast<const char*>(lv_image_get_src(img));
+    REQUIRE(first_raw != nullptr);
+    const std::string first_src(first_raw);
+
+    // Detection settles: config gains the type and PrinterState publishes it.
+    Config* cfg = Config::get_instance();
+    REQUIRE(cfg != nullptr);
+    cfg->set<std::string>(cfg->df() + helix::wizard::PRINTER_TYPE, "Voron 2.4");
+    get_printer_state().set_printer_type_sync("Voron 2.4");
+
+    helix::ui::UpdateQueue::instance().drain();
+    process_async_calls();
+
+    const std::string after_src(static_cast<const char*>(lv_image_get_src(img)));
+    INFO("the widget must re-resolve once the detected type lands in config");
+    REQUIRE(after_src != first_src);
+    REQUIRE(after_src.find("voron") != std::string::npos);
+
+    // A rebuilt panel recycles the widget instance and attaches it to a new
+    // tree; the re-armed observer must re-resolve from attach()'s reload.
+    w.detach();
+    build_tree(widget_obj, img);
+    w.attach(widget_obj, test_screen());
+    helix::ui::UpdateQueue::instance().drain();
+    process_async_calls();
+
+    const std::string recycled_src(static_cast<const char*>(lv_image_get_src(img)));
+    INFO("a recycled instance must re-resolve the settled type from attach()");
+    REQUIRE(recycled_src.find("voron") != std::string::npos);
+
+    w.detach();
 }

--- a/tests/unit/test_printer_image_widget.cpp
+++ b/tests/unit/test_printer_image_widget.cpp
@@ -298,4 +298,10 @@ TEST_CASE_METHOD(XMLTestFixture,
     REQUIRE(recycled_src.find("voron") != std::string::npos);
 
     w.detach();
+
+    // Restore the config type: the fixture resets the singleton between
+    // cases, but a same-value leftover inside this case's lifetime would
+    // have made the mid-session transition above a no-op for the next
+    // SECTION leaf.
+    cfg->set<std::string>(cfg->df() + helix::wizard::PRINTER_TYPE, "");
 }


### PR DESCRIPTION
On a fresh install detection finishes after the home panel is built, and
PrinterImageWidget resolved its image once in attach(), so the dashboard
showed the generic CoreXY silhouette until the next restart.

PrinterState now publishes a printer_type_subject string subject from
set_printer_type_internal() (guarded by the existing no-change early
return, so repeat sets do not re-notify), and the widget observes it with
an ObserverGuard armed in attach() and dropped first in detach(), so
recycled instances re-arm across rebuilds and no queued refresh can land
on a detached tree.

mutation: reverted the subject set in set_printer_type_internal();
test_printer_image_widget '[1552]' went red (fires counter stuck).
mutation: reverted the observer wiring in attach(); the re-resolve
test went red (image stayed generic after the type landed).
