### PR TITLE
fix(wizard): hide the step total until the connection settles it (prestonbrown/helixscreen#1550)

### DIFF
--- a/include/wizard_step_logic.h
+++ b/include/wizard_step_logic.h
@@ -132,6 +132,18 @@ std::vector<wizard::StepId> wizard_deferred_hardware_steps(const std::vector<Ste
 /// Count of non-skipped entries.
 int wizard_visible_count(const std::vector<StepSkip>&);
 
+/// Whether the step denominator is settled enough to display.
+///
+/// The skip vector is a function of live hardware state that only exists after
+/// the connection succeeds (AMS presence, filament sensors, and a preset the
+/// detection applies to a then-identified printer), so before that the visible
+/// count is a provisional estimate that can shrink or grow at the next step.
+/// An authoritative preset (seeded at install or applied mid-run) settles it
+/// from the first step; otherwise the Connection step is the boundary - up to
+/// and including it the total stays hidden, after it the total holds.
+bool wizard_total_is_settled(wizard::StepId current, const std::vector<StepSkip>& steps,
+                             bool has_preset);
+
 /// 1-based display number for `current`: 1 + number of visible entries strictly
 /// before it.
 int wizard_display_number(wizard::StepId current, const std::vector<StepSkip>&);

--- a/src/system/wizard_step_logic.cpp
+++ b/src/system/wizard_step_logic.cpp
@@ -138,6 +138,22 @@ int wizard_visible_count(const std::vector<StepSkip>& steps) {
     return count;
 }
 
+bool wizard_total_is_settled(wizard::StepId current, const std::vector<StepSkip>& steps,
+                             bool has_preset) {
+    if (has_preset) {
+        // The preset plan already collapsed everything it will collapse;
+        // the denominator is stable from the first step.
+        return true;
+    }
+    const int idx = index_of(current, steps);
+    if (idx < 0) {
+        return false;
+    }
+    // Steps after Connection run with a live, fully discovered printer, so
+    // the skip vector can no longer change under them.
+    return idx > index_of(wizard::StepId::Connection, steps);
+}
+
 int wizard_display_number(wizard::StepId current, const std::vector<StepSkip>& steps) {
     int idx = index_of(current, steps);
     int upper = (idx < 0) ? 0 : idx;

--- a/src/ui/ui_wizard.cpp
+++ b/src/ui/ui_wizard.cpp
@@ -62,6 +62,7 @@ static lv_subject_t total_steps;
 static lv_subject_t wizard_title;
 static lv_subject_t wizard_step_current;  // String for display, e.g., "1"
 static lv_subject_t wizard_step_total;    // String for display, e.g., "7"
+static lv_subject_t wizard_total_visible; // Int: 0 until the denominator is settled
 static lv_subject_t wizard_is_final_step; // Int: 0=not final, 1=final (for button visibility)
 static lv_subject_t wizard_back_visible;
 
@@ -280,6 +281,7 @@ void ui_wizard_init_subjects() {
                               "wizard_step_current", wizard_subjects_);
     UI_MANAGED_SUBJECT_STRING(wizard_step_total, wizard_step_total_buffer, "9", "wizard_step_total",
                               wizard_subjects_);
+    UI_MANAGED_SUBJECT_INT(wizard_total_visible, 1, "wizard_total_visible", wizard_subjects_);
     UI_MANAGED_SUBJECT_INT(wizard_is_final_step, 0, "wizard_is_final_step", wizard_subjects_);
     UI_MANAGED_SUBJECT_STRING(wizard_subtitle, wizard_subtitle_buffer, "", "wizard_subtitle",
                               wizard_subjects_);
@@ -523,6 +525,7 @@ void ui_wizard_navigate_to_step(helix::wizard::StepId step) {
     int display_total;
     bool at_first_visible;
     bool is_last_step;
+    bool total_visible = true;
     if (!g_step_subset.empty()) {
         int sub_idx = subset_index_of(step);
         if (sub_idx < 0) {
@@ -535,6 +538,11 @@ void ui_wizard_navigate_to_step(helix::wizard::StepId step) {
     } else {
         display_step = helix::wizard_display_number(step, skips);
         display_total = helix::wizard_visible_count(skips);
+        // The denominator is an estimate until the connection settles what
+        // exists on this printer (AMS, sensors, and a detection-applied
+        // preset all reshape the skip vector mid-run); show it only once it
+        // cannot lurch.
+        total_visible = helix::wizard_total_is_settled(step, skips, ctx.preset.skip_hardware);
         at_first_visible = !helix::wizard_prev(step, skips).has_value();
         is_last_step = helix::wizard_is_last(step, skips);
     }
@@ -542,6 +550,8 @@ void ui_wizard_navigate_to_step(helix::wizard::StepId step) {
     // Update current_step subject (internal step index for UI bindings)
     crash_handler::breadcrumb::note("wiz", "notify_current", static_cast<long>(step_idx));
     lv_subject_set_int(&current_step, step_idx);
+    crash_handler::breadcrumb::note("wiz", "notify_total_vis", static_cast<long>(step_idx));
+    lv_subject_set_int(&wizard_total_visible, total_visible ? 1 : 0);
 
     // Back button: visible when there is a previous non-skipped step, or when an
     // add-printer cancel callback is registered (shown as "Cancel" on step one).

--- a/tests/unit/test_wizard_step_logic.cpp
+++ b/tests/unit/test_wizard_step_logic.cpp
@@ -418,3 +418,50 @@ TEST_CASE("Preset authority: session flag is off until identify applies a preset
     helix::wizard_reset_preset_session_state();
     REQUIRE_FALSE(helix::wizard_preset_applied_this_session());
 }
+
+TEST_CASE("Total settles only after connection when no preset is authoritative",
+          "[1550][wizard][step_logic]") {
+    auto v = full_vec();
+
+    // Through the connection step the skip vector is still an estimate: AMS,
+    // filament sensors and a detection-applied preset only exist once the
+    // connection succeeds, so the denominator can shrink or grow mid-run.
+    REQUIRE_FALSE(helix::wizard_total_is_settled(StepId::TouchCalibration, v, false));
+    REQUIRE_FALSE(helix::wizard_total_is_settled(StepId::Language, v, false));
+    REQUIRE_FALSE(helix::wizard_total_is_settled(StepId::Wifi, v, false));
+    REQUIRE_FALSE(helix::wizard_total_is_settled(StepId::Connection, v, false));
+
+    // Everything after the connection runs against a live, fully discovered
+    // printer; the denominator cannot lurch from here.
+    REQUIRE(helix::wizard_total_is_settled(StepId::PrinterIdentify, v, false));
+    REQUIRE(helix::wizard_total_is_settled(StepId::HeaterSelect, v, false));
+    REQUIRE(helix::wizard_total_is_settled(StepId::Summary, v, false));
+    REQUIRE(helix::wizard_total_is_settled(StepId::Telemetry, v, false));
+}
+
+TEST_CASE("Total settles from the first step when a preset is authoritative",
+          "[1550][wizard][step_logic]") {
+    auto v = full_vec();
+    skip_step(v, StepId::Wifi);
+    skip_step(v, StepId::Connection);
+    skip_step(v, StepId::PrinterIdentify);
+    skip_step(v, StepId::HeaterSelect);
+
+    // The preset plan already collapsed everything it will collapse, so the
+    // denominator is stable even on the first step and on a skipped
+    // Connection.
+    REQUIRE(helix::wizard_total_is_settled(StepId::TouchCalibration, v, true));
+    REQUIRE(helix::wizard_total_is_settled(StepId::Language, v, true));
+    REQUIRE(helix::wizard_total_is_settled(StepId::Connection, v, true));
+    REQUIRE(helix::wizard_total_is_settled(StepId::Telemetry, v, true));
+}
+
+TEST_CASE("An unknown step never reports the total as settled without a preset",
+          "[1550][wizard][step_logic]") {
+    auto v = full_vec();
+    v.pop_back(); // drop Telemetry so a lookup misses
+    REQUIRE_FALSE(helix::wizard_total_is_settled(StepId::Telemetry, v, false));
+    // A preset short-circuits before any step lookup: the denominator is
+    // settled regardless of what the step is.
+    REQUIRE(helix::wizard_total_is_settled(StepId::Telemetry, v, true));
+}

--- a/tests/unit/test_wizard_targeted.cpp
+++ b/tests/unit/test_wizard_targeted.cpp
@@ -96,15 +96,19 @@ TEST_CASE_METHOD(LVGLUITestFixture,
     // wizard_step_current / wizard_step_total are STRING subjects (e.g., "1", "2").
     // wizard_is_final_step is an INT subject (0 = not final, 1 = final).
     // wizard_back_visible is an INT subject (0 = hidden, 1 = visible).
+    // wizard_total_visible stays 1 in a targeted session: the subset IS the
+    // settled denominator, so "of N" must not hide.
     lv_subject_t* step_cur = lv_xml_get_subject(nullptr, "wizard_step_current");
     lv_subject_t* step_tot = lv_xml_get_subject(nullptr, "wizard_step_total");
     lv_subject_t* is_final = lv_xml_get_subject(nullptr, "wizard_is_final_step");
     lv_subject_t* back_vis = lv_xml_get_subject(nullptr, "wizard_back_visible");
+    lv_subject_t* total_vis = lv_xml_get_subject(nullptr, "wizard_total_visible");
 
     REQUIRE(step_cur != nullptr);
     REQUIRE(step_tot != nullptr);
     REQUIRE(is_final != nullptr);
     REQUIRE(back_vis != nullptr);
+    REQUIRE(total_vis != nullptr);
 
     // At HeaterSelect (subset index 0): step "1" of "2", NOT final.
     // Back button hidden: first subset step with no cancel callback registered.
@@ -112,6 +116,7 @@ TEST_CASE_METHOD(LVGLUITestFixture,
     REQUIRE(std::string(lv_subject_get_string(step_tot)) == "2");
     REQUIRE(lv_subject_get_int(is_final) == 0);
     REQUIRE(lv_subject_get_int(back_vis) == 0);
+    REQUIRE(lv_subject_get_int(total_vis) == 1);
 
     // Navigate to the second (and last) subset step — exercises the
     // !g_step_subset.empty() branch of ui_wizard_navigate_to_step directly.
@@ -121,9 +126,38 @@ TEST_CASE_METHOD(LVGLUITestFixture,
     REQUIRE(std::string(lv_subject_get_string(step_cur)) == "2");
     REQUIRE(std::string(lv_subject_get_string(step_tot)) == "2");
     REQUIRE(lv_subject_get_int(is_final) == 1);
+    REQUIRE(lv_subject_get_int(total_vis) == 1);
 
     // Tear down.
     ui_wizard_complete_targeted();
     REQUIRE(completed);
     REQUIRE(ui_wizard_active_step_subset().empty());
+}
+
+// Full-flow (no subset) navigation: the "of N" pair must hide through the
+// connection step - where the denominator is still an estimate - and appear
+// once the wizard is past it. The lurch this prevents: detection applies a
+// preset between steps, and "Step 2 of 6" -> "Step 3 of 3" reads as the wizard
+// skipping something (or "1 of 7" -> "2 of 11" growing) while both were honest
+// recomputations.
+TEST_CASE_METHOD(LVGLUITestFixture,
+                 "full-flow wizard hides the step total until the connection settles it",
+                 "[1550][wizard]") {
+    ui_wizard_init_subjects();
+
+    lv_subject_t* total_vis = lv_xml_get_subject(nullptr, "wizard_total_visible");
+    REQUIRE(total_vis != nullptr);
+
+    // Language and Wifi sit before Connection: total hidden.
+    ui_wizard_navigate_to_step(StepId::Language);
+    REQUIRE(lv_subject_get_int(total_vis) == 0);
+    ui_wizard_navigate_to_step(StepId::Wifi);
+    REQUIRE(lv_subject_get_int(total_vis) == 0);
+
+    // Past the connection the printer is discovered and the denominator holds.
+    ui_wizard_navigate_to_step(StepId::PrinterIdentify);
+    REQUIRE(lv_subject_get_int(total_vis) == 1);
+
+    // No deinit: other wizard tests in this shard reuse these process-wide
+    // subjects, and init_subjects() is idempotent for the next one.
 }

--- a/ui_xml/wizard_header_bar.xml
+++ b/ui_xml/wizard_header_bar.xml
@@ -11,13 +11,20 @@
             style_pad_all="0">
       <!-- Title: "Printer Setup: Network", etc. -->
       <text_heading name="wizard_title" bind_text="wizard_title"/>
-      <!-- Progress: "Step X of Y" - separate elements for translation -->
+      <!-- Progress: "Step X of Y" - separate elements for translation.
+           The "of Y" pair hides while the denominator is still an estimate:
+           the skip vector reshapes itself once the connection settles the
+           printer's hardware, and a total that can lurch reads as a lie. -->
       <lv_obj name="wizard_progress"
               width="content" height="content" flex_flow="row" style_pad_all="0" style_pad_gap="4">
         <text_small text="Step" translation_tag="Step"/>
         <text_small name="wizard_step_current" bind_text="wizard_step_current"/>
-        <text_small text="of" translation_tag="of"/>
-        <text_small name="wizard_step_total" bind_text="wizard_step_total"/>
+        <text_small text="of" translation_tag="of">
+          <bind_flag_if_not_eq subject="wizard_total_visible" flag="hidden" ref_value="1"/>
+        </text_small>
+        <text_small name="wizard_step_total" bind_text="wizard_step_total">
+          <bind_flag_if_not_eq subject="wizard_total_visible" flag="hidden" ref_value="1"/>
+        </text_small>
       </lv_obj>
     </lv_obj>
     <!-- Row 2: Subtitle (contextual hint) -->


### PR DESCRIPTION
On a generic install the wizard showed a provisional denominator that
lurched the moment detection applied a preset mid-run: 'Step 2 of 6'
became 'Step 3 of 3' between adjacent screens (or grew, '1 of 7' ->
'2 of 11'), reading as the wizard skipping steps. Both numbers were
honest recomputations of a skip vector that is genuinely a function of
which printer this is - information that does not exist before the
connection succeeds.

wizard_total_is_settled() hides the 'of N' pair (via the
wizard_total_visible subject) through the Connection step unless an
authoritative preset settled the plan from step one. Targeted subset
sessions keep their totals: the subset IS the settled denominator.

mutation: reverted the settled-call, the subject set, the subject init
and the header-bar binding in turn; the [1550] cases each went red
(4 killed, 4 uncompilable as build-load-bearing declarations).
