### PR TITLE
perf(theme): skip the full theme rebuild when nothing changed (prestonbrown/helixscreen#1526)

### DIFF
--- a/include/theme_manager.h
+++ b/include/theme_manager.h
@@ -323,10 +323,27 @@ class ThemeManager {
  * Creates and applies LVGL theme with light or dark mode.
  * Must be called before creating any widgets.
  *
+ * When called again with the same display (same pointer and resolution) and
+ * the same mode while nothing deinitialized the theme in between, this is a
+ * no-op: the registration pass re-reads and parses the whole ui_xml/ tree,
+ * which is exactly the cost the test suite paid once per fixture instance for
+ * a theme that never changed between them. The runtime dark-mode toggle goes
+ * through theme_manager_apply_theme(), and responsive republishing through
+ * theme_manager_refresh_*(), so a skipped repeat is always a true repeat.
+ *
  * @param display LVGL display instance
  * @param use_dark_mode true for dark theme, false for light theme
  */
 void theme_manager_init(lv_display_t* display, bool use_dark_mode);
+
+/**
+ * @brief How many times theme_manager_init() performed a full rebuild
+ *
+ * The no-op path above does not count. Exists so tests can pin the guard
+ * without timing anything.
+ */
+// NAMESPACE_OK: joins the global theme_manager_init/deinit family
+int theme_manager_full_init_count();
 
 /**
  * @brief Deinitialize theme subjects before lv_deinit()

--- a/src/ui/theme_manager.cpp
+++ b/src/ui/theme_manager.cpp
@@ -145,6 +145,15 @@ static lv_theme_t* current_theme = nullptr;
 static bool use_dark_mode = true;
 static lv_display_t* theme_display = nullptr;
 
+// Repeat-guard state for theme_manager_init(): the display pointer, its
+// resolution and the mode of the last FULL rebuild, plus a count of rebuilds.
+// A repeat call for an unchanged target skips the whole registration pass,
+// which otherwise re-parses ui_xml/ from scratch on every fixture instance.
+static bool theme_fully_initialized = false;
+static int32_t theme_init_h_res = 0;
+static int32_t theme_init_v_res = 0;
+static int theme_full_init_count = 0;
+
 static helix::ThemeData active_theme;
 
 // Theme change notification subject (monotonically increasing generation counter)
@@ -754,13 +763,15 @@ static ThemePalette convert_to_theme_palette(const theme_palette_t* p,
 }
 
 /**
- * @brief Initialize the HelixScreen LVGL theme
+ * @brief Sync the mutable palette manager to active_theme
  *
- * Sets up ThemeManager, initializes extra widget styles, and registers
- * the helix_theme with LVGL.
+ * The legacy ThemeManager can be flipped in place (dark-mode toggle,
+ * palette previews, tests); the next theme_manager_init() call is the
+ * boundary that restores it to the canonical theme and mode. Pure
+ * in-memory conversion - no file or XML parsing - so both the full init
+ * and the repeat-skip path can afford it.
  */
-static lv_theme_t* theme_init_lvgl(lv_display_t* display, const theme_palette_t* palette,
-                                   bool is_dark, const lv_font_t* base_font) {
+static void resync_palette_manager(bool is_dark) {
     // Build palettes from active_theme for contrast calculations.
     // For single-mode themes, use the valid palette for both sides to avoid
     // parsing empty color strings from the unsupported mode.
@@ -779,8 +790,20 @@ static lv_theme_t* theme_init_lvgl(lv_display_t* display, const theme_palette_t*
     tm.set_palettes(light_pal, dark_pal);
     tm.init();
     tm.set_dark_mode(is_dark);
+}
+
+/**
+ * @brief Initialize the HelixScreen LVGL theme
+ *
+ * Sets up ThemeManager, initializes extra widget styles, and registers
+ * the helix_theme with LVGL.
+ */
+static lv_theme_t* theme_init_lvgl(lv_display_t* display, const theme_palette_t* palette,
+                                   bool is_dark, const lv_font_t* base_font) {
+    resync_palette_manager(is_dark);
 
     // Initialize widget-specific styles not in StyleRole enum
+    const auto& props = active_theme.properties;
     init_extra_styles(palette, resolve_border_radius(props));
 
     // Create LVGL default theme as base (we'll layer on top)
@@ -1814,8 +1837,34 @@ static helix::ThemeData theme_manager_load_active_theme() {
 
 void theme_manager_init(lv_display_t* display, bool use_dark_mode_param) {
     auto tm_init_start = std::chrono::steady_clock::now();
+
+    // Repeat guard: the same display at the same size in the same mode, with
+    // the theme still initialized, needs nothing re-registered. theme_manager_
+    // apply_theme() owns mode changes and theme_manager_refresh_*() owns
+    // republishing, and theme_manager_deinit() clears theme_subject_initialized,
+    // so every path that actually changes the state re-runs.
+    const int32_t h_res = display ? lv_display_get_horizontal_resolution(display) : 0;
+    const int32_t v_res = display ? lv_display_get_vertical_resolution(display) : 0;
+    if (theme_fully_initialized && theme_display == display &&
+        use_dark_mode_param == use_dark_mode && h_res == theme_init_h_res &&
+        v_res == theme_init_v_res && theme_subject_initialized) {
+        // The registration pass can stay skipped, but the mutable palette
+        // manager still has to come back to the canonical theme: tests and
+        // theme-preview paths flip it in place, and the next init call is the
+        // boundary that restores it. A no-op flip is cheap (the setters
+        // early-return), so this costs nothing on a repeat that changed
+        // nothing.
+        resync_palette_manager(use_dark_mode_param);
+        spdlog::debug("[Theme] theme_manager_init: unchanged target ({}x{} {}), reusing", h_res,
+                      v_res, use_dark_mode_param);
+        return;
+    }
+
     theme_display = display;
     use_dark_mode = use_dark_mode_param;
+    theme_init_h_res = h_res;
+    theme_init_v_res = v_res;
+    theme_full_init_count++;
 
     // Initialize theme change notification subject
     if (!theme_subject_initialized) {
@@ -2016,6 +2065,12 @@ void theme_manager_init(lv_display_t* display, bool use_dark_mode_param) {
                       std::chrono::steady_clock::now() - tm_init_start)
                       .count(),
                   helix::theme_tokens::enabled() ? "on" : "off");
+    theme_fully_initialized = true;
+}
+
+// NAMESPACE_OK: joins the global theme_manager_init/deinit family
+int theme_manager_full_init_count() {
+    return theme_full_init_count;
 }
 
 void theme_manager_deinit() {

--- a/tests/unit/test_theme_init_repeat.cpp
+++ b/tests/unit/test_theme_init_repeat.cpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2025-2026 356C LLC
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * theme_manager_init() repeat guard. The registration pass re-reads and
+ * expat-parses the whole ui_xml/ tree, and the test suite paid that cost once
+ * per fixture instance (once per SECTION leaf) for a theme that never changed
+ * between them — ~26% of main-thread time. An unchanged target (same display
+ * pointer, resolution and mode, theme still initialized) now skips the pass.
+ */
+
+#include "../lvgl_ui_test_fixture.h"
+#include "theme_manager.h"
+
+#include "../catch_amalgamated.hpp"
+
+TEST_CASE_METHOD(LVGLUITestFixture, "theme_manager_init skips repeats for an unchanged target",
+                 "[1526][theme]") {
+    const int before = theme_manager_full_init_count();
+
+    // The fixture's own init_theme() ran as part of construction; a manual
+    // repeat for the same display/mode must not rebuild.
+    theme_manager_init(lv_display_get_default(), false);
+    REQUIRE(theme_manager_full_init_count() == before);
+
+    // A second identical repeat is also a no-op.
+    theme_manager_init(lv_display_get_default(), false);
+    REQUIRE(theme_manager_full_init_count() == before);
+
+    // A mode change is a real change.
+    theme_manager_init(lv_display_get_default(), true);
+    REQUIRE(theme_manager_full_init_count() == before + 1);
+
+    // And so is flipping back — this is also what restores the light mode the
+    // rest of the fixture expects.
+    theme_manager_init(lv_display_get_default(), false);
+    REQUIRE(theme_manager_full_init_count() == before + 2);
+}
+
+TEST_CASE_METHOD(LVGLUITestFixture, "a deinitialized theme runs the full init again",
+                 "[1526][theme]") {
+    const int before = theme_manager_full_init_count();
+
+    theme_manager_deinit();
+    theme_manager_init(lv_display_get_default(), false);
+    REQUIRE(theme_manager_full_init_count() == before + 1);
+
+    // Deinit cleared the subject-initialized flag, so the NEXT repeat skips
+    // again — the recovery is one rebuild, not a permanently disabled guard.
+    theme_manager_init(lv_display_get_default(), false);
+    REQUIRE(theme_manager_full_init_count() == before + 1);
+}


### PR DESCRIPTION
theme_manager_init() re-reads and expat-parses the whole ui_xml/ tree on
every call, and the test suite paid that cost once per fixture instance
(once per SECTION leaf) for a theme that never changed between them:
~26% averaged and up to 85% peak of main-thread time. A repeat call for
the same display pointer, resolution and mode now skips the registration
pass entirely; the mutable palette manager still resyncs to the
canonical theme on the skip path, because dark-mode toggles and palette
previews flip it in place and the next init call is the boundary that
restores it. theme_manager_deinit() clears the subject flag, so shutdown
and re-init still rebuild fully.

Unsharded suite on this box: 315s -> 165s (~47% cut).

mutation: reverted the repeat guard; the [1526] count cases went red.
The resync half is pinned by the pre-existing [reactive-icon] cases,
which went red when the skip path omitted it mid-development; the
palette-conversion extraction is build-load-bearing (uncompilable
reverted), as are the new statics and the counter accessor.
