### PR TITLE
feat(ams): publish per-slot error state and severity subjects (prestonbrown/helixscreen#1527)

### DIFF
--- a/include/ams_state.h
+++ b/include/ams_state.h
@@ -1161,6 +1161,29 @@ class AmsState {
     [[nodiscard]] lv_subject_t* get_slot_lane_state_subject(int slot_index);
 
     /**
+     * @brief Get per-slot error-flag subject
+     *
+     * 1 when the slot is BLOCKED or carries a SlotError, else 0 - the same
+     * derivation the lane-bar consumers compute from SlotInfo. XML name:
+     * ams_slot_<n>_has_error.
+     *
+     * @param slot_index Slot index (0 to MAX_SLOTS-1)
+     * @return Subject pointer or nullptr if out of range
+     */
+    [[nodiscard]] lv_subject_t* get_slot_has_error_subject(int slot_index);
+
+    /**
+     * @brief Get per-slot error-severity subject
+     *
+     * Holds SlotError::Severity as int; INFO when the slot carries no error.
+     * XML name: ams_slot_<n>_error_severity.
+     *
+     * @param slot_index Slot index (0 to MAX_SLOTS-1)
+     * @return Subject pointer or nullptr if out of range
+     */
+    [[nodiscard]] lv_subject_t* get_slot_error_severity_subject(int slot_index);
+
+    /**
      * @brief Get slot color subject for a specific backend and slot
      *
      * For backend_index 0, delegates to existing flat slot subjects.
@@ -1964,6 +1987,8 @@ class AmsState {
     lv_subject_t slot_toolhead_present_[MAX_SLOTS]; // int: 0/1 per-slot toolhead sensor
     lv_subject_t slot_active_loaded_[MAX_SLOTS];    // int: 0/1 firmware seated & loaded
     lv_subject_t slot_lane_states_[MAX_SLOTS];      // int: helix::ui::LaneState (classify_lane)
+    lv_subject_t slot_has_error_[MAX_SLOTS];        // int: 0/1 BLOCKED or carries a SlotError
+    lv_subject_t slot_error_severity_[MAX_SLOTS];   // int: SlotError::Severity (INFO when none)
 
     // Per-unit environment subjects (CFS temp/humidity)
     lv_subject_t unit_temp_[MAX_UNITS];     // int: tenths of C (270 = 27.0C), 0 = no data

--- a/src/printer/ams_state.cpp
+++ b/src/printer/ams_state.cpp
@@ -58,6 +58,16 @@ namespace {
 // Shutdown flag to prevent async callbacks from accessing destroyed singleton
 static std::atomic<bool> s_shutdown_flag{false};
 
+/// The error state a lane bar's status line draws from: the same derivation
+/// both current consumers (AMS overview mini bars, mini status) compute from
+/// SlotInfo. has_error covers a carried SlotError AND a BLOCKED lane;
+/// severity falls back to INFO when no error object is carried.
+void slot_error_state(const SlotInfo& slot, bool& has_error, int& severity) {
+    has_error = (slot.status == SlotStatus::BLOCKED || slot.error.has_value());
+    severity =
+        static_cast<int>(slot.error.has_value() ? slot.error->severity : SlotError::Severity::INFO);
+}
+
 struct AsyncSyncData {
     int backend_index;
     bool full_sync;
@@ -491,6 +501,23 @@ void AmsState::init_subjects(bool register_xml) {
             snprintf(name_buf, sizeof(name_buf), "ams_slot_%d_lane_state", i);
             lv_xml_register_subject(nullptr, name_buf, &slot_lane_states_[i]);
         }
+
+        // Per-slot error state, published so a lane bar can draw its own
+        // status line from subjects. has_error = BLOCKED or a carried
+        // SlotError; severity defaults to INFO when no error is carried.
+        lv_subject_init_int(&slot_has_error_[i], 0);
+        subjects_.register_subject(&slot_has_error_[i]);
+        if (register_xml) {
+            snprintf(name_buf, sizeof(name_buf), "ams_slot_%d_has_error", i);
+            lv_xml_register_subject(nullptr, name_buf, &slot_has_error_[i]);
+        }
+
+        lv_subject_init_int(&slot_error_severity_[i], static_cast<int>(SlotError::Severity::INFO));
+        subjects_.register_subject(&slot_error_severity_[i]);
+        if (register_xml) {
+            snprintf(name_buf, sizeof(name_buf), "ams_slot_%d_error_severity", i);
+            lv_xml_register_subject(nullptr, name_buf, &slot_error_severity_[i]);
+        }
     }
 
     // Per-unit environment subjects (CFS temperature/humidity)
@@ -805,6 +832,10 @@ void AmsState::register_xml_subject_names() {
         lv_xml_register_subject(nullptr, name_buf, &slot_active_loaded_[i]);
         snprintf(name_buf, sizeof(name_buf), "ams_slot_%d_lane_state", i);
         lv_xml_register_subject(nullptr, name_buf, &slot_lane_states_[i]);
+        snprintf(name_buf, sizeof(name_buf), "ams_slot_%d_has_error", i);
+        lv_xml_register_subject(nullptr, name_buf, &slot_has_error_[i]);
+        snprintf(name_buf, sizeof(name_buf), "ams_slot_%d_error_severity", i);
+        lv_xml_register_subject(nullptr, name_buf, &slot_error_severity_[i]);
     }
 
     // Per-unit environment subjects (CFS temperature/humidity)
@@ -1290,6 +1321,20 @@ lv_subject_t* AmsState::get_slot_lane_state_subject(int slot_index) {
         return nullptr;
     }
     return &slot_lane_states_[slot_index];
+}
+
+lv_subject_t* AmsState::get_slot_has_error_subject(int slot_index) {
+    if (slot_index < 0 || slot_index >= MAX_SLOTS) {
+        return nullptr;
+    }
+    return &slot_has_error_[slot_index];
+}
+
+lv_subject_t* AmsState::get_slot_error_severity_subject(int slot_index) {
+    if (slot_index < 0 || slot_index >= MAX_SLOTS) {
+        return nullptr;
+    }
+    return &slot_error_severity_[slot_index];
 }
 
 lv_subject_t* AmsState::get_slot_remaining_subject(int slot_index) {
@@ -1962,6 +2007,19 @@ void AmsState::sync_from_backend() {
                 any_slot_changed = true;
             }
 
+            // Error flag + severity for the lane's status line.
+            bool new_has_error = false;
+            int new_severity = static_cast<int>(SlotError::Severity::INFO);
+            slot_error_state(*slot, new_has_error, new_severity);
+            if (lv_subject_get_int(&slot_has_error_[i]) != (new_has_error ? 1 : 0)) {
+                lv_subject_set_int(&slot_has_error_[i], new_has_error ? 1 : 0);
+                any_slot_changed = true;
+            }
+            if (lv_subject_get_int(&slot_error_severity_[i]) != new_severity) {
+                lv_subject_set_int(&slot_error_severity_[i], new_severity);
+                any_slot_changed = true;
+            }
+
             // Fill percent (canonical display_fill_pct encoding). The ams_slot
             // widget observes this — so spool fill renders from state on every
             // panel, not just the ones that remember to push it imperatively.
@@ -2279,6 +2337,15 @@ void AmsState::sync_from_backend() {
             lv_subject_set_int(&slot_lane_states_[i], default_lane_state);
             any_slot_changed = true;
         }
+        if (lv_subject_get_int(&slot_has_error_[i]) != 0) {
+            lv_subject_set_int(&slot_has_error_[i], 0);
+            any_slot_changed = true;
+        }
+        int default_severity = static_cast<int>(SlotError::Severity::INFO);
+        if (lv_subject_get_int(&slot_error_severity_[i]) != default_severity) {
+            lv_subject_set_int(&slot_error_severity_[i], default_severity);
+            any_slot_changed = true;
+        }
         // Clear remaining filament for unused slots
         if (strcmp(lv_subject_get_string(&slot_remaining_[i]), "") != 0) {
             lv_subject_copy_string(&slot_remaining_[i], "");
@@ -2360,6 +2427,19 @@ void AmsState::update_slot(int slot_index) {
             helix::ui::classify_lane(slot.status, helix::ui::lane_has_identity(slot)));
         if (lv_subject_get_int(&slot_lane_states_[slot_index]) != new_lane_state) {
             lv_subject_set_int(&slot_lane_states_[slot_index], new_lane_state);
+            changed = true;
+        }
+
+        // Error flag + severity, same derivation as the full-sync loop.
+        bool new_has_error = false;
+        int new_severity = static_cast<int>(SlotError::Severity::INFO);
+        slot_error_state(slot, new_has_error, new_severity);
+        if (lv_subject_get_int(&slot_has_error_[slot_index]) != (new_has_error ? 1 : 0)) {
+            lv_subject_set_int(&slot_has_error_[slot_index], new_has_error ? 1 : 0);
+            changed = true;
+        }
+        if (lv_subject_get_int(&slot_error_severity_[slot_index]) != new_severity) {
+            lv_subject_set_int(&slot_error_severity_[slot_index], new_severity);
             changed = true;
         }
 

--- a/tests/unit/test_ams_realtime_filament_state.cpp
+++ b/tests/unit/test_ams_realtime_filament_state.cpp
@@ -605,3 +605,100 @@ TEST_CASE_METHOD(LVGLTestFixture, "AMS clears filament_loaded after unload compl
     ams.clear_backends();
     ams.deinit_subjects();
 }
+
+// ============================================================================
+// Part 3 — per-slot error state subjects (ams_slot_<n>_has_error /
+// ams_slot_<n>_error_severity): the same derivation the lane-bar consumers
+// compute from SlotInfo, published so a lane bar can draw its own status line
+// from subjects instead of from a snapshot.
+// ============================================================================
+
+TEST_CASE_METHOD(LVGLTestFixture, "AmsState publishes per-slot error state and severity on sync",
+                 "[1527][ams][ams_state]") {
+    auto& ams = AmsState::instance();
+    ams.init_subjects(false);
+
+    auto backend = std::make_unique<AmsBackendMock>(4);
+    auto* backend_ptr = backend.get();
+    ams.set_backend(std::move(backend));
+
+    SECTION("accessors return non-null in range and null out of range") {
+        CHECK(ams.get_slot_has_error_subject(0) != nullptr);
+        CHECK(ams.get_slot_error_severity_subject(0) != nullptr);
+        CHECK(ams.get_slot_has_error_subject(-1) == nullptr);
+        CHECK(ams.get_slot_error_severity_subject(AmsState::MAX_SLOTS) == nullptr);
+    }
+
+    SECTION("a carried error publishes has_error=1 and its severity") {
+        backend_ptr->set_slot_error(0, SlotError{"lane jammed", SlotError::Severity::ERROR});
+        ams.sync_from_backend();
+        drain();
+
+        CHECK(lv_subject_get_int(ams.get_slot_has_error_subject(0)) == 1);
+        CHECK(lv_subject_get_int(ams.get_slot_error_severity_subject(0)) ==
+              static_cast<int>(SlotError::Severity::ERROR));
+        // Neighbor slots stay quiet.
+        CHECK(lv_subject_get_int(ams.get_slot_has_error_subject(1)) == 0);
+        CHECK(lv_subject_get_int(ams.get_slot_error_severity_subject(1)) ==
+              static_cast<int>(SlotError::Severity::INFO));
+    }
+
+    SECTION("clearing the error resets the flag and falls back to INFO") {
+        backend_ptr->set_slot_error(0, SlotError{"lane jammed", SlotError::Severity::WARNING});
+        ams.sync_from_backend();
+        drain();
+        REQUIRE(lv_subject_get_int(ams.get_slot_has_error_subject(0)) == 1);
+
+        backend_ptr->set_slot_error(0, std::nullopt);
+        ams.sync_from_backend();
+        drain();
+        CHECK(lv_subject_get_int(ams.get_slot_has_error_subject(0)) == 0);
+        CHECK(lv_subject_get_int(ams.get_slot_error_severity_subject(0)) ==
+              static_cast<int>(SlotError::Severity::INFO));
+    }
+
+    SECTION("a BLOCKED lane without an error object still publishes has_error=1") {
+        // force_slot_status, not set_slot_info: status is firmware-derived and
+        // set_slot_info deliberately ignores it, like every real backend.
+        backend_ptr->force_slot_status(0, SlotStatus::BLOCKED);
+        backend_ptr->set_slot_error(0, std::nullopt);
+        ams.sync_from_backend();
+        drain();
+
+        CHECK(lv_subject_get_int(ams.get_slot_has_error_subject(0)) == 1);
+        CHECK(lv_subject_get_int(ams.get_slot_error_severity_subject(0)) ==
+              static_cast<int>(SlotError::Severity::INFO));
+    }
+
+    SECTION("the single-slot fast path publishes the same state") {
+        backend_ptr->set_slot_error(0, SlotError{"gate jam", SlotError::Severity::WARNING});
+        ams.update_slot(0);
+        drain();
+
+        CHECK(lv_subject_get_int(ams.get_slot_has_error_subject(0)) == 1);
+        CHECK(lv_subject_get_int(ams.get_slot_error_severity_subject(0)) ==
+              static_cast<int>(SlotError::Severity::WARNING));
+    }
+
+    SECTION("slots beyond a shrinking backend reset to no-error") {
+        backend_ptr->set_slot_error(3, SlotError{"tail jam", SlotError::Severity::ERROR});
+        ams.sync_from_backend();
+        drain();
+        REQUIRE(lv_subject_get_int(ams.get_slot_has_error_subject(3)) == 1);
+
+        // Swap in a backend that reports only two slots: slot 3 must clear.
+        ams.set_backend(std::make_unique<AmsBackendMock>(2));
+        ams.sync_from_backend();
+        drain();
+
+        CHECK(lv_subject_get_int(ams.get_slot_has_error_subject(3)) == 0);
+        CHECK(lv_subject_get_int(ams.get_slot_error_severity_subject(3)) ==
+              static_cast<int>(SlotError::Severity::INFO));
+    }
+
+    SECTION("re-entry with register_xml publishes the XML names") {
+        ams.init_subjects(true);
+        CHECK(lv_xml_get_subject(nullptr, "ams_slot_0_has_error") != nullptr);
+        CHECK(lv_xml_get_subject(nullptr, "ams_slot_0_error_severity") != nullptr);
+    }
+}


### PR DESCRIPTION
The lane-bar consumers derive has_error (BLOCKED or a carried SlotError)
and severity (the error's severity, INFO when none) from SlotInfo on
every rebuild; the shared lane widget cannot, because a widget binds
subjects, not snapshots. AmsState now publishes ams_slot_<n>_has_error
and ams_slot_<n>_error_severity alongside the other nine per-slot
subjects, updated in the full-sync loop, the single-slot fast path and
the shrinking-backend clear loop from one shared derivation helper.

mutation: reverted each of the three update sites, the init
registration and the re-entry name registration in turn; the [1527]
cases went red (5 killed, 4 uncompilable declarations).
