### PR TITLE
chore(afc): cite the upstream tip-method request and ratchet the marker baseline (prestonbrown/helixscreen#1515)

### DIFF
--- a/scripts/quality-checks.sh
+++ b/scripts/quality-checks.sh
@@ -1495,7 +1495,7 @@ if [ -f "scripts/check_todo_markers.py" ]; then
   # constraint on the same line, or sits in a file another change is rewriting.
   # The number may go DOWN (fix one, then lower this baseline) but must never
   # go up. Always whole-tree: a marker is a marker whichever commit adds it.
-  if python3 scripts/check_todo_markers.py --max-allowed 9 --summary >/tmp/todo_markers.out 2>&1; then
+  if python3 scripts/check_todo_markers.py --max-allowed 8 --summary >/tmp/todo_markers.out 2>&1; then
     echo ""
     tail -1 /tmp/todo_markers.out
   else

--- a/src/printer/ams_backend_afc.cpp
+++ b/src/printer/ams_backend_afc.cpp
@@ -5696,8 +5696,9 @@ void AmsBackendAfc::load_afc_configs() {
             spdlog::info("[AMS AFC] Config files loaded");
 
             // Detect tip method from AFC config.
-            // TODO: Replace with direct Moonraker status query once AFC exposes
-            // tool_cut/form_tip in get_status() (upstream AFC enhancement pending).
+            // MARKER(AFCProject/AFC-Klipper-Add-On#863): parse configs until
+            // upstream exposes tool_cut/form_tip in get_status(), then read
+            // the status field instead.
             update_tip_method_from_config();
 
             emit_event(EVENT_STATE_CHANGED);


### PR DESCRIPTION
The AFC tip-method workaround comment pointed at a pending enhancement
that was never filed anywhere; the request is now real
(AFCProject/AFC-Klipper-Add-On#863), the marker cites it, and the
work-marker baseline drops 9 -> 8. The actual fix - reading the tip
method from get_status() - waits on upstream.

Marker gate: 8 remaining markers, ratcheted down one.
