### PR TITLE
feat(ui): toolhead guards arrive by construction via moves_machine (prestonbrown/helixscreen#1518)

### DIFF
--- a/tests/unit/test_job_holds_machine.cpp
+++ b/tests/unit/test_job_holds_machine.cpp
@@ -245,6 +245,42 @@ TEST_CASE_METHOD(XMLTestFixture, "the bypass tile is disabled during a host-side
 }
 
 // ============================================================================
+// The guard arrives by construction
+//
+// The moves_machine attribute is what makes "did anyone forget one" answerable:
+// the engine installs the job_holds_machine -> disabled binding for the
+// element itself, so a machine-moving control is guarded the moment its XML
+// says it moves the machine. This test pins that construction, not a spelling.
+// ============================================================================
+
+TEST_CASE_METHOD(XMLTestFixture, "moves_machine installs the toolhead guard by construction",
+                 "[ui][xml][job_holds_machine]") {
+    const char* attrs[] = {"moves_machine", "true", nullptr};
+    lv_obj_t* control = static_cast<lv_obj_t*>(lv_xml_create(test_screen(), "lv_obj", attrs));
+    REQUIRE(control != nullptr);
+
+    REQUIRE_FALSE(lv_obj_has_state(control, LV_STATE_DISABLED));
+
+    // A host-side pre-print block: print_active stays 0 and only the
+    // lifecycle subject moves.
+    state().update_from_status(nlohmann::json{{"print_stats", {{"state", "standby"}}}});
+    state().set_print_start_state(helix::PrintStartPhase::BED_MESH, "", 0);
+    for (int pass = 0; pass < 8; ++pass) {
+        helix::ui::UpdateQueue::instance().drain();
+    }
+
+    REQUIRE(lv_subject_get_int(state().get_print_active_subject()) == 0);
+    REQUIRE(lv_obj_has_state(control, LV_STATE_DISABLED));
+
+    // And it releases - a latched-disabled control is the failure mode.
+    state().set_print_start_state(helix::PrintStartPhase::IDLE, "", 0);
+    for (int pass = 0; pass < 8; ++pass) {
+        helix::ui::UpdateQueue::instance().drain();
+    }
+    REQUIRE_FALSE(lv_obj_has_state(control, LV_STATE_DISABLED));
+}
+
+// ============================================================================
 // The census
 //
 // The gate walks every .xml under ui_xml/ and asks one question per file: does
@@ -268,13 +304,7 @@ namespace {
 
 constexpr const char* kSubject = "job_holds_machine";
 constexpr const char* kDisabled = "state=\"disabled\"";
-
-/// The only two spellings that pin the direction. Matching the subject name
-/// alone would accept ref_value="0" - a control live while the toolhead is busy
-/// and dead when it is free, the exact inversion - and leave the census whole.
-constexpr const char* kGuardEqForm =
-    "<bind_state_if_eq subject=\"job_holds_machine\" state=\"disabled\" ref_value=\"1\"/>";
-constexpr const char* kGuardCompoundPrefix = "<bind_state_if cond=\"job_holds_machine eq 1 or ";
+constexpr const char* kGuardAttribute = "moves_machine=\"true\"";
 
 struct GuardedFile {
     const char* path;
@@ -612,28 +642,22 @@ size_t count_occurrences(const std::string& haystack, const std::string& needle)
 }
 
 struct GuardScan {
-    size_t recognized = 0;                 ///< guards in a direction-pinning form
+    size_t recognized = 0;                 ///< moves_machine="true" attributes
     size_t mentions = 0;                   ///< every occurrence of the subject name
-    std::vector<std::string> unrecognized; ///< binds naming the subject some other way
+    std::vector<std::string> unrecognized; ///< bindings naming the subject directly
 };
 
 GuardScan scan_guards(const std::string& xml) {
     GuardScan scan;
     scan.mentions = count_occurrences(xml, kSubject);
+    scan.recognized = count_occurrences(xml, kGuardAttribute);
 
-    // A control with a second reason to be disabled cannot carry two binds:
-    // each bind_state_* both sets and clears the state, so the later one undoes
-    // the earlier. Those fold the lifecycle guard into one compound cond=,
-    // which still pins the direction and still counts.
+    // The attribute is the ONLY way to carry the guard now: a hand-written
+    // bind naming the subject is the failure this gate exists to prevent
+    // (it rots: it can be forgotten, or its spelling can drift). The engine
+    // installs the binding for moves_machine by construction.
     for (const std::string& bind : state_binds(xml)) {
-        if (bind.find(kSubject) == std::string::npos) {
-            continue;
-        }
-        const bool compound =
-            bind.rfind(kGuardCompoundPrefix, 0) == 0 && bind.find(kDisabled) != std::string::npos;
-        if (bind == kGuardEqForm || compound) {
-            ++scan.recognized;
-        } else {
+        if (bind.find(kSubject) != std::string::npos) {
             scan.unrecognized.push_back(bind);
         }
     }
@@ -717,18 +741,21 @@ TEST_CASE("each guarded file carries exactly the toolhead guards its census row 
             for (const std::string& bind : scan.unrecognized) {
                 odd += "\n  " + bind;
             }
-            INFO(row.path << " names job_holds_machine in a bind this gate does not read as a "
-                             "guard:"
-                          << odd << "\nA guard is spelled either\n  " << kGuardEqForm << "\nor\n  "
-                          << kGuardCompoundPrefix << "...\" " << kDisabled << "/>");
+            INFO(row.path << " names job_holds_machine in a hand-written bind. The guard "
+                             "arrives by construction from the moves_machine attribute now; "
+                             "a direct bind is the failure mode this gate exists to prevent:"
+                          << odd
+                          << "\nCarry the guard as moves_machine=\"true\" on the "
+                             "control instead.");
             REQUIRE(scan.unrecognized.empty());
         }
         {
             INFO(row.path << " names job_holds_machine " << scan.mentions << " times and only "
                           << scan.recognized
-                          << " of those are binds, so the rest are prose. Say it in words that "
-                             "are not the subject name.");
-            REQUIRE(scan.recognized == scan.mentions);
+                          << " of those are covered by moves_machine guards, so the rest are "
+                             "prose that claims a guard without carrying one. Say it in words "
+                             "that are not the subject name.");
+            REQUIRE(scan.mentions <= scan.recognized);
         }
         INFO(row.path << " pins " << row.guards << " toolhead guards and carries "
                       << scan.recognized

--- a/tools/xml-linter/schema/schema.json
+++ b/tools/xml-linter/schema/schema.json
@@ -159,6 +159,9 @@
         "hidden_if_empty": {
           "type": "string"
         },
+        "moves_machine": {
+          "type": "bool"
+        },
         "bind_checked": {
           "type": "string"
         }

--- a/ui_xml/ams_device_operations.xml
+++ b/ui_xml/ams_device_operations.xml
@@ -11,17 +11,14 @@
     <lv_obj name="overlay_content"
             width="100%" flex_grow="1" style_pad_all="#space_md" scrollable="true" flex_flow="column"
             style_pad_gap="#space_md">
-
       <!-- System info line (e.g. "System: AFC · v1.2.3") -->
       <text_muted name="system_info_label" width="100%" bind_text="ams_device_ops_system_info"/>
-
       <!-- ================================================================== -->
       <!-- Card 1: Quick Actions & Behavior                                    -->
       <!-- ================================================================== -->
       <ui_card name="quick_actions_card"
                width="100%" height="content" style_radius="#border_radius" style_pad_all="#space_md" flex_flow="column"
                style_pad_gap="#space_md">
-
         <!-- Quick Actions Header -->
         <lv_obj width="100%"
                 height="content" style_pad_all="0" flex_flow="row" style_flex_cross_place="center"
@@ -29,7 +26,6 @@
           <icon src="flash" size="sm" variant="primary"/>
           <text_body text="Quick Actions" translation_tag="Quick Actions"/>
         </lv_obj>
-
         <!-- Action Buttons Row: Home | Recover | Abort -->
         <lv_obj name="action_buttons_row"
                 width="100%" height="content" style_pad_all="0" flex_flow="row" style_pad_gap="#space_sm"
@@ -48,16 +44,13 @@
             <event_cb trigger="clicked" callback="on_ams_device_ops_abort"/>
           </ui_button>
         </lv_obj>
-
         <!-- Divider -->
         <lv_obj width="100%" height="1" style_bg_color="#text_muted" style_bg_opa="30"/>
-
         <!-- Bypass Mode Container (hidden when bypass not supported) -->
         <lv_obj name="bypass_container"
                 width="100%" height="content" style_pad_all="0" style_layout="flex" style_flex_flow="column"
                 scrollable="false">
           <bind_flag_if_eq subject="ams_device_ops_supports_bypass" flag="hidden" ref_value="0"/>
-
           <!-- Virtual toggle (no hardware sensor) -->
           <lv_obj name="bypass_virtual_row"
                   width="100%" height="content" style_pad_all="0" flex_flow="row" style_flex_main_place="space_between"
@@ -80,13 +73,11 @@
                  "success" reports a fire-and-forget gcode as done. Dims while a
                  job owns the toolhead, same binding as panel_widget_bypass.xml;
                  the shared controller still enforces that guard on every tap. -->
-            <ui_switch name="bypass_toggle" size="small">
+            <ui_switch name="bypass_toggle" size="small" moves_machine="true">
               <bind_state_if_eq subject="ams_bypass_active" state="checked" ref_value="1"/>
-              <bind_state_if_eq subject="job_holds_machine" state="disabled" ref_value="1"/>
               <event_cb trigger="value_changed" callback="on_ams_device_ops_bypass_toggled"/>
             </ui_switch>
           </lv_obj>
-
           <!-- Hardware sensor indicator (read-only) -->
           <lv_obj name="bypass_hw_row"
                   width="100%" height="content" style_pad_all="0" flex_flow="row" style_flex_main_place="space_between"
@@ -104,7 +95,6 @@
             <status_pill name="bypass_status_pill" text="Inactive" translation_tag="Inactive" variant="muted"/>
           </lv_obj>
         </lv_obj>
-
         <!-- Auto-Heat Info Row (shown when supported) -->
         <lv_obj name="auto_heat_row"
                 width="100%" height="content" style_pad_all="0" flex_flow="row" style_flex_main_place="start"
@@ -122,7 +112,6 @@
           <!-- Right side: Status indicator -->
           <icon src="check_circle" size="sm" variant="primary"/>
         </lv_obj>
-
         <!-- AFC Unload-After-Print toggle (AFC backends only) -->
         <setting_toggle_row name="row_afc_unload_after_print"
                             label="Unloads After Print" label_tag="Unloads After Print" icon="filament"
@@ -131,7 +120,6 @@
                             subject="afc_unload_after_print" callback="on_ams_afc_unload_after_print_toggled">
           <bind_flag_if_eq subject="ams_device_ops_is_afc" flag="hidden" ref_value="0"/>
         </setting_toggle_row>
-
         <!-- Keep the bypass spool on the Multi-Filament panel even when bypass
              is disengaged. AFC publishes a virtual bypass whether or not one is
              wired, so the node is hidden by default (AFC backends only). -->
@@ -142,7 +130,6 @@
                             subject="ams_always_show_bypass_spool" callback="on_ams_always_show_bypass_spool_toggled">
           <bind_flag_if_eq subject="ams_device_ops_is_afc" flag="hidden" ref_value="0"/>
         </setting_toggle_row>
-
         <!-- Retention across eject: keep the previously assigned spool details
              so reloading the same spool after maintenance needs no re-selection
              (default on). Turn off to start fresh whenever a lane empties.
@@ -168,7 +155,6 @@
           <bind_flag_if_eq subject="ams_device_ops_printer_retains_spool_info" flag="hidden" ref_value="0"/>
           <bind_flag_if_eq subject="ams_device_ops_reports_spool_ids" flag="hidden" ref_value="0"/>
         </text_small>
-
         <!-- Offer the bypass controls on a machine whose firmware reports none.
              Shown only while the firmware says no, so it stays available for the
              user to switch back off. Happy Hare defaults [mmu_machine] has_bypass
@@ -182,7 +168,6 @@
                             subject="ams_force_bypass_controls" callback="on_ams_force_bypass_controls_toggled">
           <bind_flag_if_eq subject="ams_device_ops_fw_supports_bypass" flag="hidden" ref_value="1"/>
         </setting_toggle_row>
-
         <!-- QIDI Box eject distance (QIDI backends only) -->
         <lv_obj name="row_qidi_eject_distance"
                 width="100%" height="content" style_pad_all="0" flex_flow="column" style_pad_gap="#space_sm"
@@ -217,7 +202,6 @@
             <text_small width="40" text="2000"/>
           </lv_obj>
         </lv_obj>
-
         <!-- QIDI Box eject velocity (QIDI backends only) -->
         <lv_obj name="row_qidi_eject_velocity"
                 width="100%" height="content" style_pad_all="0" flex_flow="column" style_pad_gap="#space_sm"
@@ -252,7 +236,6 @@
             <text_small width="40" text="300"/>
           </lv_obj>
         </lv_obj>
-
         <!-- Reset Endless Spool failover (shown only on backends whose
              endless-spool mapping the UI may write — AFC per-slot edges,
              single-unit Happy Hare groups, and the mock. Read-only systems
@@ -268,7 +251,6 @@
                             callback="on_ams_reset_endless_spool_clicked">
           <bind_flag_if_eq subject="ams_device_ops_can_reset_endless_spool" flag="hidden" ref_value="0"/>
         </setting_action_row>
-
         <!-- Status Row -->
         <lv_obj name="status_row"
                 width="100%" height="content" style_pad_all="0" flex_flow="row" style_flex_main_place="start"
@@ -281,7 +263,6 @@
           </lv_obj>
         </lv_obj>
       </ui_card>
-
       <!-- ================================================================== -->
       <!-- Section List (progressive disclosure — rows push detail overlays) -->
       <!-- ================================================================== -->
@@ -295,7 +276,6 @@
           <!-- Section rows added dynamically: icon + label + chevron -->
         </lv_obj>
       </ui_card>
-
       <!-- ================================================================== -->
       <!-- No Backend Message (shown when no AMS connected)                   -->
       <!-- ================================================================== -->
@@ -308,7 +288,6 @@
                     width="100%" text="No Multi-Filament System connected."
                     translation_tag="No Multi-Filament System connected." style_text_align="center"/>
       </ui_card>
-
     </lv_obj>
   </view>
 </component>

--- a/ui_xml/components/ams_sidebar.xml
+++ b/ui_xml/components/ams_sidebar.xml
@@ -4,17 +4,14 @@
 <component>
   <!--
     AMS Sidebar - Shared right-column component for AMS panels.
-
     Contains: current loaded card, status/progress display, action buttons.
     Used by both ams_panel.xml and ams_overview_panel.xml.
-
     Callbacks (registered by AmsOperationSidebar::register_callbacks_static()):
     - ams_sidebar_bypass_toggled: Bypass toggle switch
     - ams_sidebar_unload_clicked: Unload button
     - ams_sidebar_reset_clicked: Reset button
     - ams_sidebar_check_gates_clicked: Check slots button (Happy Hare only)
     - ams_sidebar_settings_clicked: Settings button
-
     C++ companion: AmsOperationSidebar (ui_ams_sidebar.h)
   -->
   <view name="ams_sidebar"
@@ -60,9 +57,8 @@
              Dims while a job owns the toolhead, same binding as
              panel_widget_bypass.xml; BypassToggleController still enforces that
              guard on every tap. -->
-        <ui_switch name="bypass_switch" size="small">
+        <ui_switch name="bypass_switch" size="small" moves_machine="true">
           <bind_state_if_eq subject="ams_bypass_active" state="checked" ref_value="1"/>
-          <bind_state_if_eq subject="job_holds_machine" state="disabled" ref_value="1"/>
           <event_cb trigger="value_changed" callback="ams_sidebar_bypass_toggled"/>
         </ui_switch>
       </lv_obj>

--- a/ui_xml/components/panel_widget_bypass.xml
+++ b/ui_xml/components/panel_widget_bypass.xml
@@ -8,13 +8,12 @@
 <component>
   <view name="panel_widget_bypass"
         extends="lv_obj" height="100%" flex_grow="1" style_pad_all="0" scrollable="false" flex_flow="column"
-        style_flex_main_place="center" style_flex_cross_place="center" style_pad_gap="#space_xxs" clickable="true">
+        style_flex_main_place="center" style_flex_cross_place="center" style_pad_gap="#space_xxs" clickable="true"
+        moves_machine="true">
     <event_cb trigger="clicked" callback="bypass_widget_clicked_cb"/>
     <!-- Whole tile dims + refuses while a job owns the toolhead. Same derived
          subject binding as controls_panel.xml's Save Z-Offset button; the
          controller still enforces the guard on every toggle(). -->
-    <bind_state_if_eq subject="job_holds_machine" state="disabled" ref_value="1"/>
-
     <!-- State-swapped icon pair: OFF = the Device-Ops bypass-row glyph,
          ON = the filament-path bypass-node glyph. -->
     <icon name="bypass_icon_off" src="arrow_left_right" size="md" variant="muted" clickable="false" event_bubble="true">
@@ -24,13 +23,11 @@
           src="source_branch" size="md" variant="success" clickable="false" event_bubble="true" hidden="true">
       <bind_flag_if_eq subject="ams_bypass_active" flag="hidden" ref_value="0"/>
     </icon>
-
     <text_tiny text="Bypass"
                translation_tag="Bypass" style_text_color="#text_muted" style_text_align="center" clickable="false"
                event_bubble="true">
       <bind_flag_if_eq subject="show_widget_labels" flag="hidden" ref_value="0"/>
     </text_tiny>
-
     <!-- Active detail: external spool color dot + material, only while
          engaged. Color dot via bind_style_if cannot take a *dynamic* color
          (styles are static), so the dot's bg color is bound by the widget

--- a/ui_xml/controls_panel.xml
+++ b/ui_xml/controls_panel.xml
@@ -103,9 +103,8 @@
              and the save path itself all ask one question. -->
         <ui_button name="btn_save_z_offset"
                    width="100%" height="#button_height_sm" variant="success" icon="check" text="Save Z-Offset"
-                   translation_tag="Save Z-Offset" hidden="true">
+                   translation_tag="Save Z-Offset" hidden="true" moves_machine="true">
           <bind_flag_if_eq subject="z_offset_save_available" flag="hidden" ref_value="0"/>
-          <bind_state_if_eq subject="job_holds_machine" state="disabled" ref_value="1"/>
           <event_cb trigger="clicked" callback="on_controls_save_z_offset"/>
         </ui_button>
         <!-- Motion panel navigation button -->
@@ -114,7 +113,6 @@
           <event_cb trigger="clicked" callback="on_controls_quick_actions"/>
         </ui_button>
       </ui_card>
-
       <!-- Right section: E-Stop banner + Temps + Cooling -->
       <lv_obj height="100%"
               flex_grow="2" style_pad_all="0" flex_flow="column" style_pad_gap="#space_xs" style_pad_row="0"
@@ -126,7 +124,6 @@
           <bind_flag_if_eq subject="estop_visible" flag="hidden" ref_value="0"/>
           <event_cb trigger="clicked" callback="emergency_stop_clicked"/>
         </ui_button>
-
         <!-- Temps + Cooling row (always visible) -->
         <lv_obj width="100%"
                 flex_grow="1" style_pad_all="0" flex_flow="row" style_pad_gap="#space_md" scrollable="false">
@@ -327,31 +324,25 @@
                        icon_position="top" style_bg_opa="0" style_border_width="0">
               <event_cb trigger="clicked" callback="on_calibration_bed_mesh"/>
             </ui_button>
-
             <!-- Z Calibration Button -->
             <ui_button name="btn_z_calibration"
                        height="100%" flex_grow="1" icon="z_closer" text="Z Calibration" translation_tag="Z Calibration"
-                       icon_position="top" style_bg_opa="0" style_border_width="0">
-              <bind_state_if_eq subject="job_holds_machine" state="disabled" ref_value="1"/>
+                       icon_position="top" style_bg_opa="0" style_border_width="0" moves_machine="true">
               <event_cb trigger="clicked" callback="on_calibration_zoffset"/>
             </ui_button>
-
             <!-- QGL button - visible only if printer has quad_gantry_level -->
             <ui_button name="btn_qgl"
                        height="100%" flex_grow="1" icon="spirit_level" text="QGL" translation_tag="QGL"
-                       icon_position="top" style_bg_opa="0" style_border_width="0" hidden="true">
+                       icon_position="top" style_bg_opa="0" style_border_width="0" hidden="true" moves_machine="true">
               <bind_flag_if_eq subject="printer_has_qgl" flag="hidden" ref_value="0"/>
-              <bind_state_if_eq subject="job_holds_machine" state="disabled" ref_value="1"/>
               <bind_state_if_eq subject="controls_operation_in_progress" state="disabled" ref_value="1"/>
               <event_cb trigger="clicked" callback="on_controls_qgl"/>
             </ui_button>
-
             <!-- Z-Tilt button - visible only if printer has z_tilt_adjust -->
             <ui_button name="btn_z_tilt"
                        height="100%" flex_grow="1" icon="spirit_level" text="Z-Tilt" translation_tag="Z-Tilt"
-                       icon_position="top" style_bg_opa="0" style_border_width="0" hidden="true">
+                       icon_position="top" style_bg_opa="0" style_border_width="0" hidden="true" moves_machine="true">
               <bind_flag_if_eq subject="printer_has_z_tilt" flag="hidden" ref_value="0"/>
-              <bind_state_if_eq subject="job_holds_machine" state="disabled" ref_value="1"/>
               <bind_state_if_eq subject="controls_operation_in_progress" state="disabled" ref_value="1"/>
               <event_cb trigger="clicked" callback="on_controls_z_tilt"/>
             </ui_button>
@@ -360,16 +351,13 @@
           <lv_obj width="100%"
                   flex_grow="1" style_pad_all="0" flex_flow="row" style_flex_main_place="center"
                   style_flex_cross_place="center" style_pad_gap="#space_xs" scrollable="false">
-
             <!-- Bed Screws Button (hidden if screws_tilt_adjust not configured) -->
             <ui_button name="btn_screws"
                        height="100%" flex_grow="1" icon="wrench" text="Bed Screws" translation_tag="Bed Screws"
-                       icon_position="top" style_bg_opa="0" style_border_width="0" hidden="true">
+                       icon_position="top" style_bg_opa="0" style_border_width="0" hidden="true" moves_machine="true">
               <bind_flag_if_eq subject="printer_has_screws_tilt" flag="hidden" ref_value="0"/>
-              <bind_state_if_eq subject="job_holds_machine" state="disabled" ref_value="1"/>
               <event_cb trigger="clicked" callback="on_calibration_screws"/>
             </ui_button>
-
             <!-- Motors On/Off Button (disabled when motors already off) -->
             <lv_obj name="btn_motors"
                     height="100%" flex_grow="1" style_bg_opa="0" style_pad_all="0" style_pad_gap="0" clickable="true">
@@ -387,7 +375,6 @@
                 <text_small text="Motors Off" translation_tag="Motors Off"/>
               </lv_obj>
             </lv_obj>
-
             <!-- LED quick-toggle (hidden unless an LED strip is controllable).
                  Reuses LedWidget: bulb icon reflects on/off + brightness + LED
                  color, tap toggles. C++ finds light_button/light_icon by name. -->
@@ -483,20 +470,20 @@
                   height="content" style_pad_all="0" scrollable="false" flex_flow="row" style_pad_gap="#space_xs">
             <ui_button name="btn_macro_1"
                        width="0" height="#button_height" flex_grow="1" bind_text="macro_1_name" variant="secondary"
-                       style_text_font="#font_small" long_mode="wrap">
+                       style_text_font="#font_small" long_mode="wrap" moves_machine="true">
               <bind_flag_if_eq subject="macro_1_visible" flag="hidden" ref_value="0"/>
-              <!-- One state bind, two reasons. Each bind_state_* sets OR clears the state,
-                   so a second "disabled" bind on the same widget undoes the first. -->
-              <bind_state_if cond="job_holds_machine eq 1 or macro_1_available eq 0" state="disabled"/>
+              <!-- Two disable reasons that compose: moves_machine carries the
+                   job guard, this bind carries the availability half. -->
+              <bind_state_if cond="macro_1_available eq 0" state="disabled"/>
               <event_cb trigger="clicked" callback="on_controls_macro" user_data="0"/>
             </ui_button>
             <ui_button name="btn_macro_2"
                        width="0" height="#button_height" flex_grow="1" bind_text="macro_2_name" variant="secondary"
-                       style_text_font="#font_small" long_mode="wrap">
+                       style_text_font="#font_small" long_mode="wrap" moves_machine="true">
               <bind_flag_if_eq subject="macro_2_visible" flag="hidden" ref_value="0"/>
-              <!-- One state bind, two reasons. Each bind_state_* sets OR clears the state,
-                   so a second "disabled" bind on the same widget undoes the first. -->
-              <bind_state_if cond="job_holds_machine eq 1 or macro_2_available eq 0" state="disabled"/>
+              <!-- Two disable reasons that compose: moves_machine carries the
+                   job guard, this bind carries the availability half. -->
+              <bind_state_if cond="macro_2_available eq 0" state="disabled"/>
               <event_cb trigger="clicked" callback="on_controls_macro" user_data="1"/>
             </ui_button>
           </lv_obj>
@@ -505,20 +492,20 @@
                   height="content" style_pad_all="0" scrollable="false" flex_flow="row" style_pad_gap="#space_xs">
             <ui_button name="btn_macro_3"
                        width="0" height="#button_height" flex_grow="1" bind_text="macro_3_name" variant="secondary"
-                       style_text_font="#font_small" long_mode="wrap">
+                       style_text_font="#font_small" long_mode="wrap" moves_machine="true">
               <bind_flag_if_eq subject="macro_3_visible" flag="hidden" ref_value="0"/>
-              <!-- One state bind, two reasons. Each bind_state_* sets OR clears the state,
-                   so a second "disabled" bind on the same widget undoes the first. -->
-              <bind_state_if cond="job_holds_machine eq 1 or macro_3_available eq 0" state="disabled"/>
+              <!-- Two disable reasons that compose: moves_machine carries the
+                   job guard, this bind carries the availability half. -->
+              <bind_state_if cond="macro_3_available eq 0" state="disabled"/>
               <event_cb trigger="clicked" callback="on_controls_macro" user_data="2"/>
             </ui_button>
             <ui_button name="btn_macro_4"
                        width="0" height="#button_height" flex_grow="1" bind_text="macro_4_name" variant="secondary"
-                       style_text_font="#font_small" long_mode="wrap">
+                       style_text_font="#font_small" long_mode="wrap" moves_machine="true">
               <bind_flag_if_eq subject="macro_4_visible" flag="hidden" ref_value="0"/>
-              <!-- One state bind, two reasons. Each bind_state_* sets OR clears the state,
-                   so a second "disabled" bind on the same widget undoes the first. -->
-              <bind_state_if cond="job_holds_machine eq 1 or macro_4_available eq 0" state="disabled"/>
+              <!-- Two disable reasons that compose: moves_machine carries the
+                   job guard, this bind carries the availability half. -->
+              <bind_state_if cond="macro_4_available eq 0" state="disabled"/>
               <event_cb trigger="clicked" callback="on_controls_macro" user_data="3"/>
             </ui_button>
           </lv_obj>

--- a/ui_xml/header_bar.xml
+++ b/ui_xml/header_bar.xml
@@ -14,19 +14,16 @@
   -->
   <consts>
     <!-- Cap for the header's action buttons.
-
          These must fit INSIDE header_height, not merely be a comfortable
          standalone touch target. button_height's own ladder exceeds
          header_height from the LARGE tier up (72>60, 80>68, 96>80), so a
          header passing #button_height gets a button taller than its own bar;
          style_flex_cross_place centers the overflow and the top half clips off
          the screen.
-
          Applied as style_max_height rather than height, because the
          action_button_height default is `content` and those self-sized buttons
          are already correct — a cap leaves them alone and clamps only the
          oversized ones.
-
          Roughly 80% of the corresponding header_height at each tier. -->
     <px name="header_button_height_micro" value="22"/>
     <px name="header_button_height_tiny" value="26"/>
@@ -35,7 +32,6 @@
     <px name="header_button_height_large" value="48"/>
     <px name="header_button_height_xlarge" value="54"/>
     <px name="header_button_height_xxlarge" value="64"/>
-
     <!-- E-Stop spacer gutter. The slot itself holds NO button — it is a
          transparent right-most strip that reserves horizontal room so the
          title and any action buttons stay clear of the floating e-stop circle,
@@ -168,24 +164,20 @@
          action_button props because those slots are already spoken for — 14
          panels set action_button, 4 set action_button_2 — and this must be able
          to appear on any of them.
-
          Global on purpose: an unsaved offset is lost on the next Klipper
          restart no matter which screen you are looking at, so the affordance
          follows you. The Controls panel keeps its own full-width Save button
          for the moment you close the tune overlay and land back on it.
-
          z_offset_save_available is the whole rule - firmware does not auto-save
          AND something is dirty, machine-wide or per-tool - published by
          helix::zoffset so every save surface and the save path itself ask one
          question and cannot disagree.
-
          Icon-only: the micro header is 28px tall with 22px buttons and the
          title already flex-grows, so a labelled button here eats the title. -->
     <ui_button name="header_save_z_offset"
                width="content" height="$action_button_height" style_max_height="#header_button_height"
-               style_bg_color="#success" icon="check" icon_size="sm" hidden="true">
+               style_bg_color="#success" icon="check" icon_size="sm" hidden="true" moves_machine="true">
       <bind_flag_if_eq subject="z_offset_save_available" flag="hidden" ref_value="0"/>
-      <bind_state_if_eq subject="job_holds_machine" state="disabled" ref_value="1"/>
       <event_cb trigger="clicked" callback="on_header_save_z_offset"/>
     </ui_button>
     <!-- E-Stop spacer: rightmost reserved gutter — NO button inside. The

--- a/ui_xml/micro/controls_panel.xml
+++ b/ui_xml/micro/controls_panel.xml
@@ -89,9 +89,8 @@
              test and both kinds of dirtiness, machine-wide and per-tool. -->
         <ui_button name="btn_save_z_offset"
                    width="100%" height="#button_height_sm" variant="success" icon="check" text="Save Z-Offset"
-                   translation_tag="Save Z-Offset" hidden="true">
+                   translation_tag="Save Z-Offset" hidden="true" moves_machine="true">
           <bind_flag_if_eq subject="z_offset_save_available" flag="hidden" ref_value="0"/>
-          <bind_state_if_eq subject="job_holds_machine" state="disabled" ref_value="1"/>
           <event_cb trigger="clicked" callback="on_controls_save_z_offset"/>
         </ui_button>
         <!-- Motion panel navigation button -->
@@ -101,7 +100,6 @@
           <event_cb trigger="clicked" callback="on_controls_quick_actions"/>
         </ui_button>
       </ui_card>
-
       <!-- Right section: E-Stop banner + Temps + Cooling -->
       <lv_obj height="100%"
               flex_grow="2" style_pad_all="0" flex_flow="column" style_pad_gap="#space_xs" style_pad_row="0"
@@ -113,7 +111,6 @@
           <bind_flag_if_eq subject="estop_visible" flag="hidden" ref_value="0"/>
           <event_cb trigger="clicked" callback="emergency_stop_clicked"/>
         </ui_button>
-
         <!-- Temps + Cooling row (always visible) -->
         <lv_obj width="100%"
                 flex_grow="1" style_pad_all="0" flex_flow="row" style_pad_gap="#space_xs" scrollable="false">
@@ -152,7 +149,6 @@
                 <icon src="pencil" size="xs" variant="tertiary" clickable="false" event_bubble="true"/>
               </lv_obj>
             </lv_obj>
-
             <!-- Bed section (clickable) -->
             <lv_obj name="btn_bed_temp"
                     width="100%" flex_flow="row" style_flex_main_place="space_between" style_flex_cross_place="center"
@@ -272,12 +268,10 @@
                        icon_position="top" style_bg_opa="0" style_border_width="0">
               <event_cb trigger="clicked" callback="on_calibration_bed_mesh"/>
             </ui_button>
-
             <!-- Z Calibration Button -->
             <ui_button name="btn_z_calibration"
                        height="100%" flex_grow="1" icon="z_closer" text="Z Calibration" translation_tag="Z Calibration"
-                       icon_position="top" style_bg_opa="0" style_border_width="0">
-              <bind_state_if_eq subject="job_holds_machine" state="disabled" ref_value="1"/>
+                       icon_position="top" style_bg_opa="0" style_border_width="0" moves_machine="true">
               <event_cb trigger="clicked" callback="on_calibration_zoffset"/>
             </ui_button>
           </lv_obj>
@@ -285,16 +279,13 @@
           <lv_obj width="100%"
                   flex_grow="1" style_pad_all="0" flex_flow="row" style_flex_main_place="center"
                   style_flex_cross_place="center" style_pad_gap="#space_xs" scrollable="false">
-
             <!-- Bed Screws Button (hidden if screws_tilt_adjust not configured) -->
             <ui_button name="btn_screws"
                        height="100%" flex_grow="1" icon="wrench" text="Bed Screws" translation_tag="Bed Screws"
-                       icon_position="top" style_bg_opa="0" style_border_width="0" hidden="true">
+                       icon_position="top" style_bg_opa="0" style_border_width="0" hidden="true" moves_machine="true">
               <bind_flag_if_eq subject="printer_has_screws_tilt" flag="hidden" ref_value="0"/>
-              <bind_state_if_eq subject="job_holds_machine" state="disabled" ref_value="1"/>
               <event_cb trigger="clicked" callback="on_calibration_screws"/>
             </ui_button>
-
             <!-- Motors On/Off Button (disabled when motors already off) -->
             <lv_obj name="btn_motors"
                     height="100%" flex_grow="1" style_bg_opa="0" style_pad_all="0" style_pad_gap="0" clickable="true">
@@ -312,7 +303,6 @@
                 <text_small text="Motors Off" translation_tag="Motors Off"/>
               </lv_obj>
             </lv_obj>
-
             <!-- LED quick-toggle (hidden unless an LED strip is controllable).
                  Reuses LedWidget: bulb icon reflects on/off + brightness + LED
                  color, tap toggles. C++ finds light_button/light_icon by name. -->
@@ -408,27 +398,26 @@
             <!-- QGL button - visible only if printer has quad_gantry_level -->
             <ui_button name="btn_qgl"
                        width="0" height="#button_height_sm" flex_grow="1" text="Quad Gantry Level"
-                       translation_tag="Quad Gantry Level" variant="secondary" hidden="true">
+                       translation_tag="Quad Gantry Level" variant="secondary" hidden="true" moves_machine="true">
               <bind_flag_if_eq subject="printer_has_qgl" flag="hidden" ref_value="0"/>
-              <bind_state_if_eq subject="job_holds_machine" state="disabled" ref_value="1"/>
               <bind_state_if_eq subject="controls_operation_in_progress" state="disabled" ref_value="1"/>
               <event_cb trigger="clicked" callback="on_controls_qgl"/>
             </ui_button>
             <!-- Z-Tilt button - visible only if printer has z_tilt_adjust -->
             <ui_button name="btn_z_tilt"
                        width="0" height="#button_height_sm" flex_grow="1" text="Z-Tilt Adjust"
-                       translation_tag="Z-Tilt Adjust" variant="secondary" hidden="true">
+                       translation_tag="Z-Tilt Adjust" variant="secondary" hidden="true" moves_machine="true">
               <bind_flag_if_eq subject="printer_has_z_tilt" flag="hidden" ref_value="0"/>
-              <bind_state_if_eq subject="job_holds_machine" state="disabled" ref_value="1"/>
               <bind_state_if_eq subject="controls_operation_in_progress" state="disabled" ref_value="1"/>
               <event_cb trigger="clicked" callback="on_controls_z_tilt"/>
             </ui_button>
             <ui_button name="btn_macro_1"
-                       width="0" height="#button_height_sm" flex_grow="1" bind_text="macro_1_name" variant="secondary">
+                       width="0" height="#button_height_sm" flex_grow="1" bind_text="macro_1_name" variant="secondary"
+                       moves_machine="true">
               <bind_flag_if_eq subject="macro_1_visible" flag="hidden" ref_value="0"/>
-              <!-- One state bind, two reasons. Each bind_state_* sets OR clears the state,
-                   so a second "disabled" bind on the same widget undoes the first. -->
-              <bind_state_if cond="job_holds_machine eq 1 or macro_1_available eq 0" state="disabled"/>
+              <!-- Two disable reasons that compose: moves_machine carries the
+                   job guard, this bind carries the availability half. -->
+              <bind_state_if cond="macro_1_available eq 0" state="disabled"/>
               <event_cb trigger="clicked" callback="on_controls_macro" user_data="0"/>
             </ui_button>
           </lv_obj>
@@ -436,27 +425,30 @@
           <lv_obj width="100%"
                   height="content" style_pad_all="0" scrollable="false" flex_flow="row" style_pad_gap="#space_xs">
             <ui_button name="btn_macro_2"
-                       width="0" height="#button_height_sm" flex_grow="1" bind_text="macro_2_name" variant="secondary">
+                       width="0" height="#button_height_sm" flex_grow="1" bind_text="macro_2_name" variant="secondary"
+                       moves_machine="true">
               <bind_flag_if_eq subject="macro_2_visible" flag="hidden" ref_value="0"/>
-              <!-- One state bind, two reasons. Each bind_state_* sets OR clears the state,
-                   so a second "disabled" bind on the same widget undoes the first. -->
-              <bind_state_if cond="job_holds_machine eq 1 or macro_2_available eq 0" state="disabled"/>
+              <!-- Two disable reasons that compose: moves_machine carries the
+                   job guard, this bind carries the availability half. -->
+              <bind_state_if cond="macro_2_available eq 0" state="disabled"/>
               <event_cb trigger="clicked" callback="on_controls_macro" user_data="1"/>
             </ui_button>
             <ui_button name="btn_macro_3"
-                       width="0" height="#button_height_sm" flex_grow="1" bind_text="macro_3_name" variant="secondary">
+                       width="0" height="#button_height_sm" flex_grow="1" bind_text="macro_3_name" variant="secondary"
+                       moves_machine="true">
               <bind_flag_if_eq subject="macro_3_visible" flag="hidden" ref_value="0"/>
-              <!-- One state bind, two reasons. Each bind_state_* sets OR clears the state,
-                   so a second "disabled" bind on the same widget undoes the first. -->
-              <bind_state_if cond="job_holds_machine eq 1 or macro_3_available eq 0" state="disabled"/>
+              <!-- Two disable reasons that compose: moves_machine carries the
+                   job guard, this bind carries the availability half. -->
+              <bind_state_if cond="macro_3_available eq 0" state="disabled"/>
               <event_cb trigger="clicked" callback="on_controls_macro" user_data="2"/>
             </ui_button>
             <ui_button name="btn_macro_4"
-                       width="0" height="#button_height_sm" flex_grow="1" bind_text="macro_4_name" variant="secondary">
+                       width="0" height="#button_height_sm" flex_grow="1" bind_text="macro_4_name" variant="secondary"
+                       moves_machine="true">
               <bind_flag_if_eq subject="macro_4_visible" flag="hidden" ref_value="0"/>
-              <!-- One state bind, two reasons. Each bind_state_* sets OR clears the state,
-                   so a second "disabled" bind on the same widget undoes the first. -->
-              <bind_state_if cond="job_holds_machine eq 1 or macro_4_available eq 0" state="disabled"/>
+              <!-- Two disable reasons that compose: moves_machine carries the
+                   job guard, this bind carries the availability half. -->
+              <bind_state_if cond="macro_4_available eq 0" state="disabled"/>
               <event_cb trigger="clicked" callback="on_controls_macro" user_data="3"/>
             </ui_button>
           </lv_obj>

--- a/ui_xml/micro/header_bar.xml
+++ b/ui_xml/micro/header_bar.xml
@@ -115,9 +115,8 @@
          file's <consts>, and the micro override carries no consts block. -->
     <ui_button name="header_save_z_offset"
                width="content" height="$action_button_height" style_bg_color="#success" icon="check" icon_size="sm"
-               hidden="true">
+               hidden="true" moves_machine="true">
       <bind_flag_if_eq subject="z_offset_save_available" flag="hidden" ref_value="0"/>
-      <bind_state_if_eq subject="job_holds_machine" state="disabled" ref_value="1"/>
       <event_cb trigger="clicked" callback="on_header_save_z_offset"/>
     </ui_button>
     <!-- E-Stop spacer: rightmost reserved gutter — NO button inside. The

--- a/ui_xml/motion_panel.xml
+++ b/ui_xml/motion_panel.xml
@@ -168,16 +168,16 @@
                 width="100%" height="content" style_pad_all="0" scrollable="false" flex_flow="row"
                 style_pad_gap="#space_xs">
           <ui_button name="btn_qgl"
-                     width="0" height="#button_height" flex_grow="1" text="QGL" variant="secondary" hidden="true">
+                     width="0" height="#button_height" flex_grow="1" text="QGL" variant="secondary" hidden="true"
+                     moves_machine="true">
             <bind_flag_if_eq subject="printer_has_qgl" flag="hidden" ref_value="0"/>
-            <bind_state_if_eq subject="job_holds_machine" state="disabled" ref_value="1"/>
             <bind_state_if_eq subject="controls_operation_in_progress" state="disabled" ref_value="1"/>
             <event_cb trigger="clicked" callback="on_motion_qgl"/>
           </ui_button>
           <ui_button name="btn_z_tilt"
-                     width="0" height="#button_height" flex_grow="1" text="Z-Tilt" variant="secondary" hidden="true">
+                     width="0" height="#button_height" flex_grow="1" text="Z-Tilt" variant="secondary" hidden="true"
+                     moves_machine="true">
             <bind_flag_if_eq subject="printer_has_z_tilt" flag="hidden" ref_value="0"/>
-            <bind_state_if_eq subject="job_holds_machine" state="disabled" ref_value="1"/>
             <bind_state_if_eq subject="controls_operation_in_progress" state="disabled" ref_value="1"/>
             <event_cb trigger="clicked" callback="on_motion_z_tilt"/>
           </ui_button>


### PR DESCRIPTION
Part 2 of the toolhead-safety gate. The guard was a hand-written
bind_state_if_eq(job_holds_machine, disabled) per control, counted by a
gate that cannot see a machine-moving control carrying NO guard. The
helix-xml engine now installs that binding from moves_machine="true"
(prestonbrown/helix-xml#6, #7), composed with every other state binding,
and all 25 guard sites across the eight guarded files carry the
attribute instead of their hand-written binds - the compound cond=
binds split into the attribute plus their availability half. The
regenerated linter schema admits the attribute on lv_obj.

The gate re-keys on the attribute: a hand-written bind naming
job_holds_machine anywhere in ui_xml/ is now the failure itself, and a
new construction test pins that an element carrying the attribute is
disabled exactly when the subject flips.

mutation: reverted each XML hunk and the gate hunks; the [job_holds_machine]
cases went red (16 killed). The engine branch is proven by the
construction test - it fails against a helix-xml checkout lacking the
attribute - and the submodule pointer is NOT COVERED by the mutator by
design.
