### PR TITLE
build(ad5m): ship lean flags on the 128MB-class AD5M targets (prestonbrown/helixscreen#1442)

### DIFF
--- a/mk/cross.mk
+++ b/mk/cross.mk
@@ -262,6 +262,13 @@ else ifeq ($(PLATFORM_TARGET),ad5m)
     ENABLE_SCREENSAVER := no
     ENABLE_EVDEV := yes
     BUILD_SUBDIR := ad5m
+    # Mock backends are dev/test scaffolding. The Makefile defaults ENABLE_MOCKS
+    # to yes and no cross target has ever overridden it, so every shipped device
+    # binary has carried the full mock Moonraker client. mk/cross.mk is included
+    # before the Makefile's `?=`, so setting it here wins. The
+    # #ifdef HELIX_ENABLE_MOCKS guards at every consumer are already complete --
+    # the ESP32 port builds this way today.
+    ENABLE_MOCKS := no
     # Strip binary for size on memory-constrained device
     STRIP_BINARY := yes
     FONT_TIERS := medium large
@@ -297,6 +304,8 @@ else ifeq ($(PLATFORM_TARGET),ad5m-br)
     ENABLE_SCREENSAVER := no
     ENABLE_EVDEV := yes
     BUILD_SUBDIR := ad5m-br
+    # Matches the `ad5m` target's size treatment (see its ENABLE_MOCKS block).
+    ENABLE_MOCKS := no
     # No strip — buildroot strips target binaries itself
     STRIP_BINARY := no
     FONT_TIERS := medium large
@@ -826,6 +835,22 @@ SUBMODULE_CXXFLAGS += -DHELIX_MAX_FONT_TIER=$(HELIX_MAX_FONT_TIER)
 #            SUBMODULE_CXXFLAGS -- libhv throws, and its catch clauses want
 #            typeinfo for the thrown types.
 ifeq ($(PLATFORM_TARGET),cc1)
+    CFLAGS += -DNDEBUG
+    CXXFLAGS += -DNDEBUG -fno-rtti
+    SUBMODULE_CFLAGS += -DNDEBUG
+    SUBMODULE_CXXFLAGS += -DNDEBUG
+endif
+
+# AD5M sits in the same 110-128MB class as the CC1 and pays the same page-cache
+# competition with Klipper (see the block comment above).
+ifeq ($(PLATFORM_TARGET),ad5m)
+    CFLAGS += -DNDEBUG
+    CXXFLAGS += -DNDEBUG -fno-rtti
+    SUBMODULE_CFLAGS += -DNDEBUG
+    SUBMODULE_CXXFLAGS += -DNDEBUG
+endif
+
+ifeq ($(PLATFORM_TARGET),ad5m-br)
     CFLAGS += -DNDEBUG
     CXXFLAGS += -DNDEBUG -fno-rtti
     SUBMODULE_CFLAGS += -DNDEBUG

--- a/src/remote/mock_scenarios.cpp
+++ b/src/remote/mock_scenarios.cpp
@@ -3,6 +3,11 @@
 
 #include "mock_scenarios.h"
 
+// The scenario machinery drives the mock AMS backend, which is compiled out
+// of the size-constrained device builds (ENABLE_MOCKS=no); those builds get
+// an empty registry and find_scenario() always misses.
+#ifdef HELIX_ENABLE_MOCKS
+
 #include "ams_backend_mock.h"
 #include "ams_state.h"
 #include "http_executor.h"
@@ -400,3 +405,20 @@ const MockScenario* find_scenario(const std::string& name) {
 }
 
 } // namespace helix
+
+#else // !HELIX_ENABLE_MOCKS
+
+namespace helix {
+
+const std::vector<MockScenario>& get_mock_scenarios() {
+    static const std::vector<MockScenario> kEmpty;
+    return kEmpty;
+}
+
+const MockScenario* find_scenario(const std::string&) {
+    return nullptr;
+}
+
+} // namespace helix
+
+#endif // HELIX_ENABLE_MOCKS


### PR DESCRIPTION
ad5m and ad5m-br now build with ENABLE_MOCKS=no, -DNDEBUG and
-fno-rtti, matching the CC1's treatment - the AD5M's 110MB puts it in
the same page-cache competition with Klipper the CC1 block comment
describes. The cross build surfaced one unguarded consumer: the remote
mock-scenario registry drove AmsBackend::as_mock(), which does not
exist in a mock-less build, so mock_scenarios.cpp now compiles to an
empty registry under !HELIX_ENABLE_MOCKS.

Verified: make ad5m-docker completes (binary 11,872,984 bytes); the
native build and full test suites stay green. The boot check on the
real AD5M is the remaining step and stays with the issue.
